### PR TITLE
ci: added deployment steps to pipeline

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,8 @@ runs:
       with:
         lfs: 'true'
         fetch-depth: 0
-        
+        fetch-tags: true
+
     - name: 'Checkout pipeline scripts'
       uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       with:
@@ -77,14 +78,61 @@ runs:
       with:
         scanMetadataReportFile: ${{ github.workspace }}/build/sonar/report-task.txt
         
-    - name: 'Release package'
-      if: ${{ github.event_name != 'pull_request' }}
-      run: |
-        echo 'perform release'
-      shell: bash
-
     - name: Bundle reports folder
       uses: ./mobile-android-pipelines/actions/bundle-reports
+        
+    - name: Build artefact for release
+      if: ${{ github.event_name != 'pull_request' }}
+      run: |
+        ./gradlew assemble
+      shell: bash
+      
+    - name: Increment the release version using Conventional Commits
+      if: ${{ github.event_name != 'pull_request' }}
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+          
+        current_version=$(cog -v get-version)
+        echo "current_version=$current_version" >> $GITHUB_OUTPUT
+          
+        cog bump --auto
+          
+        new_version=$(cog -v get-version)
+        echo "new_version=$new_version" >> $GITHUB_OUTPUT
+      shell: bash
+      
+    - name: Publish the release
+      if: ${{ github.event_name != 'pull_request' }} && steps.versioning.outputs.current_version != steps.versioning.outputs.new_version
+      run: |
+        git push --follow-tags && git push --tags
+      shell: bash
+      with:
+        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+      
+    - name: Publish package
+      if: ${{ github.event_name != 'pull_request' }} && steps.versioning.outputs.current_version != steps.versioning.outputs.new_version
+      uses: ./mobile-android-pipelines/actions/maven-publish
+      with:
+        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+        GITHUB_ACTOR: ${{ github.actor }}
+        
+    - name: Generate Changelog
+      if: ${{ github.event_name != 'pull_request' }} && steps.versioning.outputs.current_version != steps.versioning.outputs.new_version
+      run: |
+        cog changelog --at v$(cog -v get-version) > CHANGELOG.md
+      shell: bash
+
+    - name: Upload Changelog
+      if: ${{ github.event_name != 'pull_request' }} && steps.versioning.outputs.current_version != steps.versioning.outputs.new_version
+      id: uploadBuildReports
+      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+      with:
+        name: CHANGELOG.md
+        retention-days: 1
+        if-no-files-found: error
+        path: |
+          CHANGELOG.md
 
     - name: Clean workspace
       uses: ./mobile-android-pipelines/actions/clean-workspace

--- a/action.yml
+++ b/action.yml
@@ -82,6 +82,7 @@ runs:
       shell: bash
       
     - name: Increment the release version using Conventional Commits
+      id: versioning
       if: ${{ github.event_name != 'pull_request' }}
       run: |
         git config user.name github-actions
@@ -97,26 +98,30 @@ runs:
       shell: bash
       
     - name: Publish the release
-      if: ${{ github.event_name != 'pull_request' }} && steps.versioning.outputs.current_version != steps.versioning.outputs.new_version
+      if: ${{ github.event_name != 'pull_request'
+        && steps.versioning.outputs.current_version != steps.versioning.outputs.new_version }}
       run: |
         git push --follow-tags && git push --tags
       shell: bash
 
     - name: Publish package
-      if: ${{ github.event_name != 'pull_request' }} && steps.versioning.outputs.current_version != steps.versioning.outputs.new_version
+      if: ${{ github.event_name != 'pull_request'
+        && steps.versioning.outputs.current_version != steps.versioning.outputs.new_version }}
       uses: ./mobile-android-pipelines/actions/maven-publish
       with:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
         GITHUB_ACTOR: ${{ github.actor }}
         
     - name: Generate Changelog
-      if: ${{ github.event_name != 'pull_request' }} && steps.versioning.outputs.current_version != steps.versioning.outputs.new_version
+      if: ${{ github.event_name != 'pull_request'
+        && steps.versioning.outputs.current_version != steps.versioning.outputs.new_version }}
       run: |
         cog changelog --at v$(cog -v get-version) > CHANGELOG.md
       shell: bash
 
     - name: Upload Changelog
-      if: ${{ github.event_name != 'pull_request' }} && steps.versioning.outputs.current_version != steps.versioning.outputs.new_version
+      if: ${{ github.event_name != 'pull_request'
+        && steps.versioning.outputs.current_version != steps.versioning.outputs.new_version }}
       id: uploadBuildReports
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:

--- a/action.yml
+++ b/action.yml
@@ -107,9 +107,7 @@ runs:
       run: |
         git push --follow-tags && git push --tags
       shell: bash
-      with:
-        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
-      
+
     - name: Publish package
       if: ${{ github.event_name != 'pull_request' }} && steps.versioning.outputs.current_version != steps.versioning.outputs.new_version
       uses: ./mobile-android-pipelines/actions/maven-publish

--- a/action.yml
+++ b/action.yml
@@ -21,15 +21,9 @@ runs:
       uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       with:
         lfs: 'true'
+        submodules: 'true'
         fetch-depth: 0
         fetch-tags: true
-
-    - name: 'Checkout pipeline scripts'
-      uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
-      with:
-        repository: 'govuk-one-login/mobile-android-pipelines'
-        path: mobile-android-pipelines
-        ref: ${{ inputs.action_ref }}
 
     - name: Clean workspace
       uses: ./mobile-android-pipelines/actions/clean-workspace


### PR DESCRIPTION
See successful builds on the Logging module:
Validate: https://github.com/govuk-one-login/mobile-android-logging/actions/runs/9594710459/job/26457878275?pr=45
Deploy: https://github.com/govuk-one-login/mobile-android-logging/actions/runs/9594709499/job/26457875961?pr=45

Related PR to utilise this for Logging module is here: https://github.com/govuk-one-login/mobile-android-logging/pull/45