### PR TITLE
ci: make publish step more generic to work for single-module pipelines

### DIFF
--- a/actions/maven-publish/action.yml
+++ b/actions/maven-publish/action.yml
@@ -15,10 +15,7 @@ runs:
     - name: Publish API package
       id: maven-publish
       run: |
-        ./gradlew \
-          :modules:api:publish \
-          :modules:impl:publish \
-          :modules:testdouble:publish
+        ./gradlew publish
       shell: bash
       env:
         CI: true


### PR DESCRIPTION
Simplified the publish step to work for single module pipelines.

Test run for multi-module project:
https://github.com/govuk-one-login/mobile-android-logging/actions/runs/9714827052