### PR TITLE
feat: Add default detekt rule for composables

### DIFF
--- a/buildLogic/config/detekt/detektConfig.yml
+++ b/buildLogic/config/detekt/detektConfig.yml
@@ -1,0 +1,8 @@
+config:
+  validation: true
+  warningsAsErrors: true
+
+naming:
+  FunctionNaming:
+    # https://detekt.dev/docs/introduction/compose/#functionnaming-for-compose
+    functionPattern: '[a-zA-Z][a-zA-Z0-9]*'

--- a/buildLogic/libs.versions.toml
+++ b/buildLogic/libs.versions.toml
@@ -4,7 +4,7 @@
 [versions]
 
 android-gradle = "8.7.1" # https://developer.android.com/studio/releases/gradle-plugin
-detekt-gradle = "1.23.0" # https://github.com/detekt/detekt/releases/tag/v1.23.6
+detekt-gradle = "1.23.7" # https://github.com/detekt/detekt/releases/tag/v1.23.6
 ktlint-gradle = "11.3.1" # https://github.com/JLLeitschuh/ktlint-gradle/releases
 kotlin-general = "2.0.21" # https://kotlinlang.org/docs/releases.html#release-details
 sonarqube-gradle = "5.1.0.4882" # https://github.com/SonarSource/sonar-scanner-gradle/releases

--- a/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/detekt-config.gradle.kts
+++ b/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/detekt-config.gradle.kts
@@ -1,19 +1,24 @@
 package uk.gov.pipelines
 
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
+import uk.gov.pipelines.config.buildLogicDir
 
 project.plugins.apply("io.gitlab.arturbosch.detekt")
 
 configure<DetektExtension>(setupDetekt())
 
 fun setupDetekt(): DetektExtension.() -> Unit = {
+    val configDefaultFile = file(
+        "${project.buildLogicDir}/config/detekt/detektConfig.yml"
+    )
     val configOverrideFile = file(
         "${project.rootProject.projectDir}/config/detekt/detektConfig.yml"
     )
-    val detektToolVersion = "1.23.1"
+    val detektToolVersion = "1.23.7"
 
     allRules = true
     buildUponDefaultConfig = true
+    config.from(configDefaultFile)
     if (configOverrideFile.exists()) {
         logger.info("Detekt configuration: Using config file: $configOverrideFile")
         config.from(configOverrideFile)

--- a/test-project/libs.versions.toml
+++ b/test-project/libs.versions.toml
@@ -1,11 +1,21 @@
 [versions]
+kotlin = "2.0.21"
+composeBom = "2024.10.00"
 junit = "4.13.2"
 androidXTestJUnit = "1.2.1"
 androidXTestCore = "1.6.1"
 androidXTestRunner = "1.6.2"
 androidXTestOrchestrator = "1.5.1"
 
+[plugins]
+kotlin-compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+
 [libraries]
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
+androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation" }
+androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
+androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidXTestJUnit" }
 androidx-test-core-ktx = { group = "androidx.test", name = "core-ktx", version.ref = "androidXTestCore" }

--- a/test-project/test-library/build.gradle.kts
+++ b/test-project/test-library/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("uk.gov.pipelines.android-lib-config")
+    alias(libs.plugins.kotlin.compose.compiler)
 }
 
 android {
@@ -7,10 +8,16 @@ android {
 }
 
 dependencies {
+    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.compose.foundation)
+    debugImplementation(libs.androidx.compose.ui.tooling)
+
     testImplementation(libs.junit)
 
     androidTestImplementation(libs.androidx.test.core.ktx)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.test.runner)
+    androidTestImplementation(libs.androidx.compose.ui.test.junit4)
+    debugImplementation(libs.androidx.compose.ui.test.manifest)
     androidTestUtil(libs.androidx.test.orchestrator)
 }

--- a/test-project/test-library/src/androidTest/java/uk/gov/pipelines/testlibrary/ComposablesTest.kt
+++ b/test-project/test-library/src/androidTest/java/uk/gov/pipelines/testlibrary/ComposablesTest.kt
@@ -1,0 +1,26 @@
+package uk.gov.pipelines.testlibrary
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ComposablesTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun myTest() {
+        composeTestRule.setContent {
+            HelloWorld()
+        }
+
+        composeTestRule
+            .onNodeWithText("Hello, world")
+            .assertIsDisplayed()
+    }
+}

--- a/test-project/test-library/src/main/kotlin/uk/gov/pipelines/testlibrary/Composables.kt
+++ b/test-project/test-library/src/main/kotlin/uk/gov/pipelines/testlibrary/Composables.kt
@@ -1,0 +1,9 @@
+package uk.gov.pipelines.testlibrary
+
+import androidx.compose.runtime.Composable
+import androidx.compose.foundation.text.BasicText
+
+@Composable
+fun HelloWorld() {
+    BasicText(text = "Hello, world")
+}


### PR DESCRIPTION
## Problem

The default detekt configuration does not allow function names to start with a capital letter meaning that Composable functions are flagged as errors.

## Solution 

- Add default detekt configuration
- Add default detekt rule to allow functions to start with a capital letter (as per [detekt docs])

Also
- Update detekt
- Add a composable to the test project
- Add a compose test to the test project

[DCMAW-10478](https://govukverify.atlassian.net/browse/DCMAW-10478)


[detekt docs]: https://detekt.dev/docs/introduction/compose/#functionnaming-for-compose

[DCMAW-10478]: https://govukverify.atlassian.net/browse/DCMAW-10478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ