### PR TITLE
ci: validate pull request name in github action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,19 +34,25 @@ runs:
 
     - name: Setup GitHub Runner workflow
       uses: ./mobile-android-pipelines/actions/setup-runner
-      
+
     - name: Verify Conventional commit standards against latest git tag
       run: cog check -l
       shell: bash
-      
+
+    - name: Verify Conventional commit standards against Pull Request title
+      if: ${{ github.event_name == 'pull_request' }}
+      uses: Oliver-Binns/Versioning@4695fba9f63bed5b557094f9a64f7a2b1a7639e8 # 1.1.0
+      with:
+        ACTION_TYPE: 'Validate'
+
     - name: Lint script files
       run: ./mobile-android-pipelines/scripts/lintProject.sh "" ""
       shell: bash
-    
+
     - name: Run gradle testing suite
       run: ./mobile-android-pipelines/scripts/runTestingSuite.sh
       shell: bash
-      
+
     - name: Upload results to sonarcloud (merge)
       if: ${{ github.event_name != 'pull_request' }}
       env:
@@ -54,7 +60,7 @@ runs:
       run: |
         ./mobile-android-pipelines/scripts/sonar/scan "BRANCH" ${{ github.ref_name }}
       shell: bash
-    
+
     - name: Upload results to sonarcloud (pull request)
       if: ${{ github.event_name == 'pull_request' }}
       env:
@@ -71,32 +77,32 @@ runs:
         SONAR_TOKEN: ${{ inputs.SONAR_TOKEN }}
       with:
         scanMetadataReportFile: ${{ github.workspace }}/build/sonar/report-task.txt
-        
+
     - name: Bundle reports folder
       uses: ./mobile-android-pipelines/actions/bundle-reports
-        
+
     - name: Build artefact for release
       if: ${{ github.event_name != 'pull_request' }}
       run: |
         ./gradlew assemble
       shell: bash
-      
+
     - name: Increment the release version using Conventional Commits
       id: versioning
       if: ${{ github.event_name != 'pull_request' }}
       run: |
         git config user.name github-actions
         git config user.email github-actions@github.com
-          
+
         current_version=$(cog -v get-version)
         echo "current_version=$current_version" >> $GITHUB_OUTPUT
-          
+
         cog bump --auto
-          
+
         new_version=$(cog -v get-version)
         echo "new_version=$new_version" >> $GITHUB_OUTPUT
       shell: bash
-      
+
     - name: Publish the release
       if: ${{ github.event_name != 'pull_request'
         && steps.versioning.outputs.current_version != steps.versioning.outputs.new_version }}
@@ -111,7 +117,7 @@ runs:
       with:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
         GITHUB_ACTOR: ${{ github.actor }}
-        
+
     - name: Generate Changelog
       if: ${{ github.event_name != 'pull_request'
         && steps.versioning.outputs.current_version != steps.versioning.outputs.new_version }}


### PR DESCRIPTION
Ensures pull request title abides by conventional commit standards. 

Consuming repositories currently squash commits into the main branch. This check improves the likeliness that commit messages to main follow conventional commit standards.