### PR TITLE
refactor!: Remove option to override version catalog

### DIFF
--- a/buildLogic/settings.gradle.kts
+++ b/buildLogic/settings.gradle.kts
@@ -16,13 +16,8 @@ dependencyResolutionManagement {
         mavenCentral()
     }
     versionCatalogs {
-        val versionCatalogPath = "../../gradle/libs.versions.toml"
         create("libs") {
-            if (file(versionCatalogPath).exists()) {
-                from(files(versionCatalogPath))
-            } else {
-                from(files("libs.versions.toml"))
-            }
+            from(files("libs.versions.toml"))
         }
     }
 }


### PR DESCRIPTION
## Problem

Currently the `buildLogic` project has own version catalog but it can be configured to use a catalog provided in a composite root project.

I feel as though this behaviour is a bit unexpected; I'd expect the pipelines project to manage it's own dependencies. I wouldn't expect the consuming (root) project to need to declare dependencies that it doesn't directly depend on, but which are required by the plugins.

## Solution

Remove the option to override the version catalog in this project.

BREAKING CHANGE

[DCMAW-10478](https://govukverify.atlassian.net/browse/DCMAW-10478)

[DCMAW-10478]: https://govukverify.atlassian.net/browse/DCMAW-10478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ