### PR TITLE
fix: Add workaround for missing project extras

### DIFF
--- a/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/config/RootProjectExtras.kt
+++ b/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/config/RootProjectExtras.kt
@@ -18,6 +18,17 @@ private object RootProjectExtras {
 internal val Project.buildLogicDir: File
     get() = rootDir.resolve(rootProjectExtra(RootProjectExtras.BUILD_LOGIC_DIR))
 
-private fun Project.rootProjectExtra(key: String): String =
-    (rootProject.extra.get(key) ?: error("Add $key to root project extras"))
+private fun Project.rootProjectExtra(key: String): String {
+    // Gradle may create a temporary project and run this code while
+    // generating accessors for pre-compiled script plugins.
+    // There is little documentation around this but some related discussion
+    // can be found at https://github.com/gradle/gradle/issues/15383.
+    // The extras are not available or required during this pass, so we can
+    // just return an empty string.
+    if (rootProject.name == "gradle-kotlin-dsl-accessors") {
+        return ""
+    }
+
+    return (rootProject.extra.get(key) ?: error("Add $key to root project extras"))
         .toString()
+}


### PR DESCRIPTION
## Problem

In certain situations, the build can fail because the Gradle project 'extras' configuration is missing. 

When the right conditions are met, Gradle, while generating accessors, may create a temporary project and run the code in our pre-compiled script plugins. A failure occurs when trying to access project extras because the temporary project does not define the project extras that our plugins expect to be present.

My understanding is that this problem surfaces when a pre-compiled script plugin is applied from another pre-compiled script plugin from another project:

```
root-project
  -> build-logic (project specific plugins)
    -> build-logic (mobile-android-pipelines shared plugins)
```


## Solution

Add a special case for when Gradle is generating accessors and silently return a fake value from the affected function.

This is a pattern I've seen in other projects: https://github.com/search?q=+%22gradle-kotlin-dsl-accessors%22&type=code

## Alternative solution

We could migrate the configuration from root project extras to Gradle properties which do seem to be available while Gradle generates accessors.

### Example before

```kotlin
// build.gradle.kts (root project)
    
val projectKey: String by rootProject.extra("mobile-android-pipelines")
val projectId: String by rootProject.extra("uk.gov.pipelines")
val buildLogicDir: String by rootProject.extra("../buildLogic")
val apkConfig by rootProject.extra(
    object: ApkConfig {
        override val applicationId: String = "uk.gov.pipelines.testproject"
        override val debugVersion: String = "DEBUG_VERSION"
        override val sdkVersions = object: ApkConfig.SdkVersions {
            override val minimum = 29
            override val target = 33
            override val compile = 34
        }
    }
)
```

### Example before
```properties
# gradle.properties (root project)
    
uk.gov.pipelines.projectKey=mobile-android-pipelines
uk.gov.pipelines.projectId=uk.gov.pipelines
uk.gov.pipelines.buildLogicDir=../buildLogic
uk.gov.pipelines.apkConfig.applicationId=uk.gov.pipelines.testproject
uk.gov.pipelines.apkConfig.debugVersion=DEBUG_VERSION
uk.gov.pipelines.apkConfig.sdkVersion.minimum=29
uk.gov.pipelines.apkConfig.sdkVersion.target=33
uk.gov.pipelines.apkConfig.sdkVersion.compile=34
```

DCMAW-10478