### PR TITLE
feat: Add Maven Group ID for plugins module

### DIFF
--- a/buildLogic/plugins/build.gradle.kts
+++ b/buildLogic/plugins/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
     alias(libs.plugins.ktlint)
 }
 
+group = "uk.gov.pipelines"
+
 gradlePlugin {
     plugins {
         register("uk.gov.publishing.config") {


### PR DESCRIPTION
## Changes

Add a Maven Group ID to the `:buildLogic:plugins` module.

## Context

This change allows consuming projects to declare a dependency on the plugins module using it's new group ID:

```toml
# my-project/libs.versions.toml

[libraries]
uk-gov-pipelines-plugins = { module = "uk.gov.pipelines:plugins" }
```

```kotlin
// my-project/build-logic/plugins/build.gradle.kts

dependencies {
    implementation(libs.uk.gov.pipelines.plugins)
}
```

This is useful when a consuming project contains plugins that need to declare an implementation dependency on these shared plugins.

[DCMAW-10478]

[DCMAW-10478]: https://govukverify.atlassian.net/browse/DCMAW-10478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ