### PR TITLE
ci: Lint build logic documentation

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -43,6 +43,17 @@ jobs:
           lfs: 'true'
           fetch-depth: 0
 
+      - name: Setup runner
+        uses: ./actions/setup-runner
+        with:
+          jdk-version: 21
+
+      - name: Lint build logic documentation
+        shell: bash
+        run: |
+          cd buildLogic
+          ./scripts/lintBuildLogicDocs.sh .
+
       - name: Lint build logic
         run: |
           cd buildLogic

--- a/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/config/RootProjectExtras.kt
+++ b/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/config/RootProjectExtras.kt
@@ -21,10 +21,10 @@ internal val Project.buildLogicDir: File
 private fun Project.rootProjectExtra(key: String): String {
     // Gradle may create a temporary project and run this code while
     // generating accessors for pre-compiled script plugins.
-    // There is little documentation around this but some related discussion
-    // can be found at https://github.com/gradle/gradle/issues/15383.
-    // The extras are not available or required during this pass, so we can
-    // just return an empty string.
+    // There is little documentation around this but you can find some
+    // related discussion at https://github.com/gradle/gradle/issues/15383.
+    // The extras aren't available or required during this pass, so just
+    // return an empty string.
     if (rootProject.name == "gradle-kotlin-dsl-accessors") {
         return ""
     }

--- a/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/emulator/EmulatorConfig.kt
+++ b/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/emulator/EmulatorConfig.kt
@@ -1,12 +1,13 @@
 package uk.gov.pipelines.emulator
 
 /**
- * Configuration for the emulator config plugin.
+ * Configuration for the emulator configuration plugin.
  *
  * @param[systemImageSources] Set of system images to generate managed devices for
  * @param[androidApiLevels] Set of Android API levels generate managed devices for
  * @param[deviceFilters] Set of filters for device profiles. For example "Pixel XL".
- *   A device profile will be included if it contains the string provided (case insensitive).
+ *   The plugin includes any device profile with a name containing the string provided
+ *   (case insensitive).
  */
 data class EmulatorConfig(
     val systemImageSources: Set<SystemImageSource>,

--- a/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/extensions/ValeExt.kt
+++ b/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/extensions/ValeExt.kt
@@ -6,7 +6,7 @@ import java.io.File
 
 /**
  * Get the custom vale configuration file defined by the project.
- * If a custom vale configuration does not exist, get the default file.
+ * If a custom vale configuration doesn't exist, get the default file.
  */
 internal fun Project.valeConfigFile(): File {
     val overrideFile = file("${rootProject.projectDir}/.vale.ini")

--- a/buildLogic/scripts/lintBuildLogicDocs.sh
+++ b/buildLogic/scripts/lintBuildLogicDocs.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Check the build logic documentation using vale
+
+BUILD_LOGIC_DIR=$1
+
+vale sync \
+  --config=${BUILD_LOGIC_DIR}/config/vale/.vale.ini
+
+vale \
+  --no-wrap \
+  --config=${BUILD_LOGIC_DIR}/config/vale/.vale.ini \
+  --glob='!**/{build,.gradle}/**' \
+  ${BUILD_LOGIC_DIR}


### PR DESCRIPTION
## Changes

- Add a step to lint the build logic documentation with vale
- Fix documentation issues in the build logic project

## Context

I have not used our custom vale plugin but have added a script instead as it was not possible to apply a plugin to the project that contains the plugin.

DCMAW-10478