### PR TITLE
feat: Add Jacoco test coverage plugin for app modules

### DIFF
--- a/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/android-app-config.gradle.kts
+++ b/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/android-app-config.gradle.kts
@@ -10,6 +10,7 @@ listOf(
     "org.jetbrains.kotlin.android",
     "uk.gov.pipelines.detekt-config",
     "uk.gov.pipelines.emulator-config",
+    "uk.gov.pipelines.jacoco-app-config",
     "uk.gov.pipelines.jvm-toolchains",
     "uk.gov.pipelines.ktlint-config",
     "uk.gov.pipelines.sonarqube-module-config",

--- a/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/extensions/LibraryExtensionExt.kt
+++ b/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/extensions/LibraryExtensionExt.kt
@@ -3,6 +3,7 @@ package uk.gov.pipelines.extensions
 import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.gradle.AppExtension
 import com.android.build.gradle.LibraryExtension
+import uk.gov.pipelines.plugins.BuildConfig
 import com.android.build.api.dsl.LibraryExtension as DslLibraryExtension
 
 /**
@@ -15,11 +16,9 @@ object LibraryExtensionExt {
      *
      * Sets up the `android.testCoverage.jacocoVersion` property with the [version] parameter.
      * Also enables instrumentation and unit test coverage.
-     *
-     * @param version The Jacoco version number as a string.
      */
-    fun LibraryExtension.decorateExtensionWithJacoco(version: String) {
-        testCoverage.jacocoVersion = version
+    fun LibraryExtension.decorateExtensionWithJacoco() {
+        testCoverage.jacocoVersion = BuildConfig.JACOCO_TOOL_VERSION
         buildTypes {
             debug {
                 this.enableAndroidTestCoverage = true
@@ -33,11 +32,9 @@ object LibraryExtensionExt {
      *
      * Sets up the `android.testCoverage.jacocoVersion` property with the [version] parameter.
      * Also enables instrumentation and unit test coverage.
-     *
-     * @param version The Jacoco version number as a string.
      */
-    fun DslLibraryExtension.decorateExtensionWithJacoco(version: String) {
-        testCoverage.jacocoVersion = version
+    fun DslLibraryExtension.decorateExtensionWithJacoco() {
+        testCoverage.jacocoVersion = BuildConfig.JACOCO_TOOL_VERSION
         buildTypes {
             debug {
                 this.enableAndroidTestCoverage = true
@@ -46,8 +43,8 @@ object LibraryExtensionExt {
         }
     }
 
-    fun ApplicationExtension.decorateExtensionWithJacoco(version: String) {
-        testCoverage.jacocoVersion = version
+    fun ApplicationExtension.decorateExtensionWithJacoco() {
+        testCoverage.jacocoVersion = BuildConfig.JACOCO_TOOL_VERSION
         buildTypes {
             debug {
                 this.enableAndroidTestCoverage = true
@@ -56,8 +53,8 @@ object LibraryExtensionExt {
         }
     }
 
-    fun AppExtension.decorateExtensionWithJacoco(version: String) {
-        this.jacoco.jacocoVersion = version
+    fun AppExtension.decorateExtensionWithJacoco() {
+        this.jacoco.jacocoVersion = BuildConfig.JACOCO_TOOL_VERSION
         buildTypes {
             this.maybeCreate("debug").apply {
                 this.enableAndroidTestCoverage = true

--- a/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/jacoco-app-config.gradle.kts
+++ b/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/jacoco-app-config.gradle.kts
@@ -1,0 +1,66 @@
+package uk.gov.pipelines
+
+import com.android.build.api.variant.ApplicationAndroidComponentsExtension
+import com.android.build.gradle.AppExtension
+import com.android.build.gradle.internal.coverage.JacocoReportTask
+import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
+import com.android.build.gradle.internal.tasks.ManagedDeviceInstrumentationTestTask
+import org.gradle.configurationcache.extensions.capitalized
+import uk.gov.pipelines.extensions.LibraryExtensionExt.decorateExtensionWithJacoco
+import uk.gov.pipelines.extensions.ProjectExtensions.debugLog
+import uk.gov.pipelines.extensions.generateDebugJacocoTasks
+
+project.plugins.apply("uk.gov.pipelines.jacoco-common-config")
+
+project.configure<AppExtension> {
+    this.decorateExtensionWithJacoco().also {
+        project.debugLog("Applied jacoco properties to application")
+    }
+
+    project.afterEvaluate {
+        this@configure.applicationVariants.forEach {
+            it.generateDebugJacocoTasks(project)
+        }
+    }
+}
+
+/**
+ * Configure managed device test tasks to also run the managed device coverage report task created
+ * by Google.
+ */
+project.configure<ApplicationAndroidComponentsExtension> {
+    onVariants(selector().withBuildType("debug")) { variant ->
+        project.afterEvaluate {
+            this.tasks.withType<ManagedDeviceInstrumentationTestTask>().filter {
+                it.name.contains(variant.name, ignoreCase = true)
+            }.forEach { instrumentationTestTask ->
+                val coverageReportTaskName =
+                    "createManagedDevice${variant.name.capitalized()}AndroidTestCoverageReport"
+                val androidCoverageReportTask =
+                    project.tasks.named(
+                        coverageReportTaskName,
+                        JacocoReportTask::class.java,
+                    )
+
+                instrumentationTestTask.finalizedBy(androidCoverageReportTask)
+                androidCoverageReportTask.configure {
+                    this.mustRunAfter(instrumentationTestTask)
+                }
+            }
+        }
+    }
+
+    finalizeDsl {
+        it.decorateExtensionWithJacoco().also {
+            project.debugLog("Applied jacoco properties to app")
+        }
+    }
+}
+
+project.afterEvaluate {
+    (this.findProperty("android") as? BaseAppModuleExtension)?.let { extension ->
+        extension.applicationVariants.forEach {
+            it.generateDebugJacocoTasks(project)
+        }
+    }
+}

--- a/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/jacoco-common-config.gradle.kts
+++ b/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/jacoco-common-config.gradle.kts
@@ -2,22 +2,16 @@ package uk.gov.pipelines
 
 import org.gradle.api.tasks.testing.Test
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.extra
-import org.gradle.kotlin.dsl.jacoco
 import org.gradle.kotlin.dsl.withType
 import org.gradle.testing.jacoco.plugins.JacocoPluginExtension
 import uk.gov.pipelines.extensions.ProjectExtensions.debugLog
 import uk.gov.pipelines.extensions.TestExt.decorateTestTasksWithJacoco
 import uk.gov.pipelines.plugins.BuildConfig
 
-plugins {
-    jacoco
-}
-
-val depJacoco: String by rootProject.extra(BuildConfig.JACOCO_TOOL_VERSION)
+project.plugins.apply("jacoco")
 
 project.configure<JacocoPluginExtension> {
-    this.toolVersion = depJacoco
+    this.toolVersion = BuildConfig.JACOCO_TOOL_VERSION
     project.logger.debug("Applied jacoco tool version to jacoco plugin")
 }
 

--- a/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/jacoco-lib-config.gradle.kts
+++ b/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/jacoco-lib-config.gradle.kts
@@ -8,16 +8,14 @@ import com.android.build.api.dsl.LibraryExtension as DslLibraryExtension
 
 project.plugins.apply("uk.gov.pipelines.jacoco-common-config")
 
-val depJacoco: String by rootProject.extra
-
 project.configure<DslLibraryExtension> {
-    decorateExtensionWithJacoco(depJacoco).also {
+    decorateExtensionWithJacoco().also {
         project.debugLog("Applied jacoco properties to Library")
     }
 }
 
 project.configure<LibraryExtension> {
-    decorateExtensionWithJacoco(depJacoco).also {
+    decorateExtensionWithJacoco().also {
         project.debugLog("Applied jacoco properties to Library")
     }
 }


### PR DESCRIPTION
## Changes

Add `jacoco-app-config` plugin which configures the Jacoco test coverage plugin for application modules.

## Context

DCMAW-10478