### PR TITLE
build: Manage tool versions using version catalog

### DIFF
--- a/buildLogic/gradle/libs.versions.toml
+++ b/buildLogic/gradle/libs.versions.toml
@@ -4,20 +4,24 @@
 [versions]
 
 android-gradle = "8.7.1" # https://developer.android.com/studio/releases/gradle-plugin
-detekt-gradle = "1.23.7" # https://github.com/detekt/detekt/releases/tag/v1.23.6
+buildconfig-gradle = "5.5.1" # https://github.com/gmazzo/gradle-buildconfig-plugin/releases
+detekt = "1.23.7" # https://github.com/detekt/detekt/releases
+jacoco-tool = "0.8.8" # https://github.com/jacoco/jacoco/releases
 ktlint-gradle = "12.1.1" # https://github.com/JLLeitschuh/ktlint-gradle/releases
+ktlint-cli = "0.50.0" # https://github.com/pinterest/ktlint/releases
 kotlin-general = "2.0.21" # https://kotlinlang.org/docs/releases.html#release-details
 sonarqube-gradle = "5.1.0.4882" # https://github.com/SonarSource/sonar-scanner-gradle/releases
 
 [libraries]
 
 android-build-tool = { group = "com.android.tools.build", name = "gradle", version.ref = "android-gradle" }
-detekt-gradle = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt-gradle" }
+detekt-gradle = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
 kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin-general" }
 ktlint-gradle = { group = "org.jlleitschuh.gradle", name = "ktlint-gradle", version.ref = "ktlint-gradle" }
 sonarqube-gradle = { module = "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin", version.ref = "sonarqube-gradle" }
 
 [plugins]
 
-detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt-gradle" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint-gradle" }
+buildconfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildconfig-gradle" }

--- a/buildLogic/plugins/build.gradle.kts
+++ b/buildLogic/plugins/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `java-gradle-plugin`
     alias(libs.plugins.detekt)
     alias(libs.plugins.ktlint)
+    alias(libs.plugins.buildconfig)
 }
 
 group = "uk.gov.pipelines"
@@ -32,4 +33,10 @@ ktlint {
     filter {
         exclude { it.file.absolutePath.contains("/build/") }
     }
+}
+
+buildConfig {
+    buildConfigField("DETEKT_TOOL_VERSION", libs.versions.detekt.get())
+    buildConfigField("JACOCO_TOOL_VERSION", libs.versions.jacoco.tool.get())
+    buildConfigField("KTLINT_CLI_VERSION", libs.versions.ktlint.cli.get())
 }

--- a/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/detekt-config.gradle.kts
+++ b/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/detekt-config.gradle.kts
@@ -2,6 +2,7 @@ package uk.gov.pipelines
 
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import uk.gov.pipelines.config.buildLogicDir
+import uk.gov.pipelines.plugins.BuildConfig
 
 project.plugins.apply("io.gitlab.arturbosch.detekt")
 
@@ -17,7 +18,6 @@ fun setupDetekt(): DetektExtension.() -> Unit =
             file(
                 "${project.rootProject.projectDir}/config/detekt/detektConfig.yml",
             )
-        val detektToolVersion = "1.23.7"
 
         allRules = true
         buildUponDefaultConfig = true
@@ -37,5 +37,5 @@ fun setupDetekt(): DetektExtension.() -> Unit =
                 )
             },
         )
-        toolVersion = detektToolVersion
+        toolVersion = BuildConfig.DETEKT_TOOL_VERSION
     }

--- a/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/jacoco-common-config.gradle.kts
+++ b/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/jacoco-common-config.gradle.kts
@@ -8,12 +8,13 @@ import org.gradle.kotlin.dsl.withType
 import org.gradle.testing.jacoco.plugins.JacocoPluginExtension
 import uk.gov.pipelines.extensions.ProjectExtensions.debugLog
 import uk.gov.pipelines.extensions.TestExt.decorateTestTasksWithJacoco
+import uk.gov.pipelines.plugins.BuildConfig
 
 plugins {
     jacoco
 }
 
-val depJacoco: String by rootProject.extra("0.8.8")
+val depJacoco: String by rootProject.extra(BuildConfig.JACOCO_TOOL_VERSION)
 
 project.configure<JacocoPluginExtension> {
     this.toolVersion = depJacoco

--- a/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/ktlint-config.gradle.kts
+++ b/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/ktlint-config.gradle.kts
@@ -2,13 +2,14 @@ package uk.gov.pipelines
 
 import org.jlleitschuh.gradle.ktlint.KtlintExtension
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
+import uk.gov.pipelines.plugins.BuildConfig
 
 project.plugins.apply(
     "org.jlleitschuh.gradle.ktlint",
 )
 
 configure<KtlintExtension> {
-    version.set("0.50.0")
+    version.set(BuildConfig.KTLINT_CLI_VERSION)
     debug.set(true)
     verbose.set(true)
     android.set(true)


### PR DESCRIPTION
## Changes

Allow dependabot to update Jacoco, Ktlint and Detekt which were previously hardcoded into the plugin code.

- Manage tool versions for Jacoco, Ktlint and Detekt using the Gradle version catalog.
- Add [gradle-buildconfig-plugin](https://github.com/gmazzo/gradle-buildconfig-plugin) which allows us to inject version numbers from the plugin build to the plugin code.

## Context

Addresses https://github.com/govuk-one-login/mobile-android-pipelines/pull/23#discussion_r1856757646

DCMAW-10478