### PR TITLE
fix: Downgrade severity of `NewerVersionAvailable` lint

### DIFF
--- a/buildLogic/config/vale/styles/config/vocabularies/Base/accept.txt
+++ b/buildLogic/config/vale/styles/config/vocabularies/Base/accept.txt
@@ -25,6 +25,7 @@ VIZes
 [Aa]ndroid
 [Bb]io[Tt]oken
 [Cc]omposables?
+Dependabot
 [Gg]radle
 [Hh]amcrest
 [Hh]omebrew

--- a/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/extensions/LintExtensions.kt
+++ b/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/extensions/LintExtensions.kt
@@ -20,6 +20,13 @@ object LintExtensions {
                     "VectorPath",
                 ),
             )
+            informational.addAll(
+                setOf(
+                    // Manage dependency updates using Dependabot
+                    // https://gds-way.digital.cabinet-office.gov.uk/standards/tracking-dependencies.html
+                    "NewerVersionAvailable",
+                ),
+            )
             explainIssues = true
             htmlReport = true
             ignoreTestSources = true


### PR DESCRIPTION
## Problem

The default lint configuration raises an error when any dependency is out of date.

See [example failing build](https://github.com/govuk-one-login/mobile-android-pipelines/actions/runs/12070677890) on the `main` branch.

## Solution

There is no need to enforce that dependencies are completely up-to-date using lint.

[Dependencies should be updated frequently using Dependabot.](https://gds-way.digital.cabinet-office.gov.uk/standards/tracking-dependencies.html)

Downgrade severity of `NewerVersionAvailable` lint to 'informational'.

DCMAW-10478