### PR TITLE
feat: Add Github Action for uploading coverage reports

### DIFF
--- a/.github/workflows/check-build-logic.yml
+++ b/.github/workflows/check-build-logic.yml
@@ -49,6 +49,34 @@ jobs:
           cd buildLogic
           ./gradlew test
 
+      - name: Upload coverage reports
+        uses: ./actions/upload-coverage-reports
+        with:
+          name: build-logic-unit-test-coverage
+
+  sonar-scan:
+    name: Scan with Sonar
+    runs-on: ubuntu-latest
+    needs:
+      - check-build-logic
+    steps:
+
+      - name: 'Checkout codebase'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          lfs: 'true'
+          fetch-depth: 0
+
+      - name: Setup runner
+        uses: ./actions/setup-runner
+        with:
+          jdk-version: 21
+
+      - name: Download build logic unit test coverage reports
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #v4.1.8
+        with:
+          name: build-logic-unit-test-coverage
+
       - name: Scan with Sonar
         uses: ./actions/sonar-scan-pull-request
         with:

--- a/.github/workflows/check-test-project.yml
+++ b/.github/workflows/check-test-project.yml
@@ -15,8 +15,8 @@ concurrency:
 
 jobs:
 
-  check-test-project:
-    name: Check test project
+  unit-test:
+    name: Unit test
     runs-on: ubuntu-latest
     steps:
 
@@ -31,15 +31,70 @@ jobs:
         with:
           jdk-version: 21
 
-      - name: Check test project
+      - name: Check
         run: |
           cd test-project
           ./gradlew check
+
+      - name: Upload coverage reports
+        uses: ./actions/upload-coverage-reports
+        with:
+          name: test-project-unit-test-coverage
+
+  instrumentation-test:
+    name: Instrumentation test
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: 'Checkout codebase'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          lfs: 'true'
+          fetch-depth: 0
+
+      - name: Setup runner
+        uses: ./actions/setup-runner
+        with:
+          jdk-version: 21
 
       - name: Run test project instrumentation tests
         run: |
           cd test-project
           ./gradlew allDevicesCheck
+
+      - name: Upload coverage reports
+        uses: ./actions/upload-coverage-reports
+        with:
+          name: test-project-instrumentation-test-coverage
+
+  sonar-scan:
+    name: Scan with Sonar
+    runs-on: ubuntu-latest
+    needs:
+      - unit-test
+      - instrumentation-test
+    steps:
+
+      - name: 'Checkout codebase'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          lfs: 'true'
+          fetch-depth: 0
+
+      - name: Setup runner
+        uses: ./actions/setup-runner
+        with:
+          jdk-version: 21
+
+      - name: Download unit test coverage reports
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #v4.1.8
+        with:
+          name: test-project-unit-test-coverage
+
+      - name: Download instrumentation test coverage reports
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #v4.1.8
+        with:
+          name: test-project-instrumentation-test-coverage
 
       - name: Scan with Sonar
         uses: ./actions/sonar-scan-pull-request

--- a/actions/upload-coverage-reports/action.yml
+++ b/actions/upload-coverage-reports/action.yml
@@ -1,0 +1,17 @@
+name: 'Upload coverage reports'
+
+inputs:
+  name:
+    description: 'Name for the uploaded artifact'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Upload coverage reports
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+      with:
+        name: ${{ inputs.name }}
+        retention-days: 1
+        if-no-files-found: error
+        path: "**/reports/jacoco/**/*.xml"


### PR DESCRIPTION
## Problem

Users need to parallelise test jobs and then collate upload coverage in a separate job.

However, currently users need to know too much about how and where test coverage reports are stored in order to share them between jobs.

## Solution

Add a new Github Action that uploads Jacoco test coverage report files.

## How to use it

Now you can use the `actions/upload-coverage-reports` action in your workflow like so:

```yml
jobs:
  unit-tests:
    steps:
      ... # Run your tests
      - name: Upload coverage reports
        uses: ./actions/upload-coverage-reports
        with:
          name: unit-test-coverage-reports


 job-that-uses-reports:
    steps:
      - name: Download instrumentation test coverage reports
        uses: actions/download-artifact@v4
        with:
          name: unit-test-coverage-reports
      ... # Process the reports
```

You can look at the CI workflows for this repository for a real life example.