### PR TITLE
fix: Version name always evaluates to 0.1.0

### DIFF
--- a/buildLogic/plugins/build.gradle.kts
+++ b/buildLogic/plugins/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     `kotlin-dsl`
     `java-gradle-plugin`
+    `java-test-fixtures`
     jacoco
     alias(libs.plugins.detekt)
     alias(libs.plugins.ktlint)

--- a/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/extensions/ProjectExtensions.kt
+++ b/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/extensions/ProjectExtensions.kt
@@ -25,17 +25,19 @@ object ProjectExtensions {
 
     val Project.versionCode
         get() = prop("versionCode", Integer.MAX_VALUE).toInt()
-    val Project.versionName
-        get() =
-            execWithOutput {
-                workingDir = buildLogicDir.resolve("./scripts")
+    val Project.versionName: String
+        get() {
+            val scriptsDir = buildLogicDir.resolve("scripts/")
+            return execWithOutput {
+                workingDir = rootDir
                 executable = "bash"
                 standardOutput = OutputStream.nullOutputStream()
                 args =
                     listOf(
-                        "./getCurrentVersion",
+                        scriptsDir.resolve("getCurrentVersion").path,
                     )
             }
+        }
 
     private fun Project.prop(
         key: String,

--- a/buildLogic/plugins/src/test/kotlin/uk/gov/pipelines/SonarqubeRootConfigPluginTest.kt
+++ b/buildLogic/plugins/src/test/kotlin/uk/gov/pipelines/SonarqubeRootConfigPluginTest.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test
 import org.sonarqube.gradle.ActionBroadcast
 import org.sonarqube.gradle.SonarExtension
 import org.sonarqube.gradle.SonarProperties
+import uk.gov.pipelines.extras.BUILD_LOGIC_DIR
 
 class SonarqubeRootConfigPluginTest {
     private val project = ProjectBuilder.builder().build()
@@ -23,8 +24,7 @@ class SonarqubeRootConfigPluginTest {
     fun setup() {
         project.rootProject.extraProperties.set(
             "buildLogicDir",
-            // Relative to where test projects are created
-            "../../../../../../",
+            BUILD_LOGIC_DIR,
         )
         project.rootProject.extraProperties.set(
             "sonarProperties",

--- a/buildLogic/plugins/src/test/kotlin/uk/gov/pipelines/extensions/ProjectExtensionsTest.kt
+++ b/buildLogic/plugins/src/test/kotlin/uk/gov/pipelines/extensions/ProjectExtensionsTest.kt
@@ -1,0 +1,26 @@
+package uk.gov.pipelines.extensions
+
+import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.kotlin.gradle.plugin.extraProperties
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import uk.gov.pipelines.extensions.ProjectExtensions.versionName
+import uk.gov.pipelines.extras.BUILD_LOGIC_DIR
+
+class ProjectExtensionsTest {
+    private val project = ProjectBuilder.builder().build()
+
+    @BeforeEach
+    fun setup() {
+        project.rootProject.extraProperties.set(
+            "buildLogicDir",
+            BUILD_LOGIC_DIR,
+        )
+    }
+
+    @Test
+    fun `default version name`() {
+        assertEquals("0.1.0", project.versionName)
+    }
+}

--- a/buildLogic/plugins/src/testFixtures/kotlin/uk/gov/pipelines/extras/RootProjectExtras.kt
+++ b/buildLogic/plugins/src/testFixtures/kotlin/uk/gov/pipelines/extras/RootProjectExtras.kt
@@ -1,0 +1,6 @@
+package uk.gov.pipelines.extras
+
+/**
+ * Relative to where test projects are created
+ */
+const val BUILD_LOGIC_DIR = "../../../../../../"


### PR DESCRIPTION
## Problem
[DCMAW-10787](https://govukverify.atlassian.net/browse/DCMAW-10787)

The `project.versionName` extension always returns 0.1.0 which breaks version dependent behaviour such as publishing.

See https://github.com/govuk-one-login/mobile-android-ui/pull/137

## Solution

Fix the working directory for the script that evaluates the version. 

Previously this script was working inside this (mobile-android-pipelines) project, not the host project, which is versioned independently.

## Evidence

I tested locally by including the fix in another project and running `./gradlew publishToMavenLocal`. As part of [DCMAW-10665](https://govukverify.atlassian.net/browse/DCMAW-10665) we'll introduce an integration test in this project which will deploy the correctly versioned `test-library`.

[DCMAW-10665]: https://govukverify.atlassian.net/browse/DCMAW-10665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DCMAW-10787]: https://govukverify.atlassian.net/browse/DCMAW-10787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ