### PR TITLE
ci: Ignore merges when verifying commits

### DIFF
--- a/cog.toml
+++ b/cog.toml
@@ -1,2 +1,3 @@
 tag_prefix = "v"
+ignore_merge_commits = true
 


### PR DESCRIPTION
## Changes

Ignore merge commits when verifying commits.

## Context

This change allows us to merge the main branch into a PR branch and use the default commit message without failing the commit message check.

DCMAW-10665