### PR TITLE
build: remove unused required input for lint action

### DIFF
--- a/actions/lint/action.yml
+++ b/actions/lint/action.yml
@@ -1,9 +1,5 @@
 name: 'Lint'
 description: 'Lint files'
-inputs:
-  scripts-directory:
-    description: Directory of bash scripts
-    required: true
 
 runs:
   using: "composite"


### PR DESCRIPTION
Remove unused required input for lint action