### PR TITLE
fix!: Fix inability to pass Google credentials between actions

### DIFF
--- a/.github/workflows/check-deploy-test-project.yml
+++ b/.github/workflows/check-deploy-test-project.yml
@@ -71,8 +71,8 @@ jobs:
         id: retrieve-secrets
         uses: ./actions/retrieve-secrets
         with:
-          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
-          SERVICE_ACCOUNT_JSON_BASE64: ${{ secrets.SERVICE_ACCOUNT_JSON_BASE64 }}
+          keystore-base64: ${{ secrets.KEYSTORE_BASE64 }}
+          google-service-account-json-base64: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON_BASE64 }}
           working-directory: test-project
 
       - name: Generate version code
@@ -98,7 +98,7 @@ jobs:
         with:
           aab-paths: ${{ steps.bundle-release-app.outputs.aab-paths }}
           package-name: 'uk.gov.pipelines.testapp'
-          json-key-data: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}
+          google-service-account-json: ${{ steps.retrieve-secrets.outputs.google-service-account-json-file-path }}
           track: 'internal'
           working-directory: test-project
 

--- a/actions/publish-to-play-store/action.yml
+++ b/actions/publish-to-play-store/action.yml
@@ -7,8 +7,8 @@ inputs:
   package-name:
     description: 'App package name'
     required: true
-  json-key-data:
-    description: 'The service account JSON data used to authenticate with Google'
+  google-service-account-json:
+    description: 'The path to the Google service account JSON credentials file used to authenticate with Google'
     required: true
   track:
     description: 'Google Play testing track to upload to'
@@ -49,14 +49,14 @@ runs:
           echo "Package name = $PACKAGE_NAME"
         
           export SUPPLY_UPLOAD_MAX_RETRIES=5
-          bundle exec fastlane supply --package_name "${PACKAGE_NAME}" --json_key_data "${INPUT_JSON_KEY_DATA}" --aab ${AAB_PATH} --track "${INPUT_TRACK}"
+          bundle exec fastlane supply --package_name "${PACKAGE_NAME}" --json_key "${INPUT_JSON_KEY_PATH}" --aab ${AAB_PATH} --track "${INPUT_TRACK}"
         done
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       env:
         INPUT_AAB_PATHS: ${{ inputs.aab-paths }}
         INPUT_PACKAGE_NAME: ${{ inputs.package-name }}
-        INPUT_JSON_KEY_DATA: ${{  inputs.json-key-data  }}
+        INPUT_JSON_KEY_PATH: ${{ inputs.google-service-account-json }}
         INPUT_TRACK: ${{ inputs.track }}
         LC_ALL: en_US.utf8
         LANG: en_US.utf8

--- a/actions/retrieve-secrets/action.yml
+++ b/actions/retrieve-secrets/action.yml
@@ -1,12 +1,12 @@
 name: 'Decode and export secrets'
-description: 'Decodes the keystore and service account secret values and stores them in files in the config directory'
+description: 'Decodes the keystore and Google service account secret values and stores them in files in the config directory'
 
 inputs:
-  KEYSTORE_BASE64:
-    description: 'Keystore base 64'
+  keystore-base64:
+    description: 'Base64 encoded keystore (for signing apps)'
     required: true
-  SERVICE_ACCOUNT_JSON_BASE64:
-    description: 'Service account JSON base 64'
+  google-service-account-json-base64:
+    description: 'Base64 encoded Google service acccount JSON credentials (for uploading apps to Google Play)'
     required: true
   working-directory:
     description: 'The working directory for steps in this action'
@@ -15,8 +15,11 @@ inputs:
 
 outputs:
   keystore-file-path:
-    description: 'Path of the keystore (relative to the working directory)'
+    description: 'Path to the keystore file (relative to the working directory)'
     value: ${{ steps.decode-keystore.outputs.keystore-file-path }}
+  google-service-account-json-file-path:
+    description: 'Path to the Google service account JSON file (relative to the working directory)'
+    value: ${{ steps.decode-google-service-account-json.outputs.credentials-file-path }}
 
 runs:
   using: "composite"
@@ -30,18 +33,21 @@ runs:
     - name: Decode Keystore
       id: decode-keystore
       env:
-        ENCODED_STRING: ${{ inputs.KEYSTORE_BASE64 }}
+        KEYSTORE_BASE64: ${{ inputs.keystore-base64 }}
         KEYSTORE_FILE_PATH: config/keystore.jks
       run: |
-        echo "${ENCODED_STRING}" | base64 --decode > ${KEYSTORE_FILE_PATH}
+        echo "${KEYSTORE_BASE64}" | base64 --decode > ${KEYSTORE_FILE_PATH}
         echo "keystore-file-path=${KEYSTORE_FILE_PATH}" >> "$GITHUB_OUTPUT"
       shell: bash
       working-directory: ${{ inputs.working-directory }}
 
-    - name: Decode Service Account
+    - name: Decode Google service account JSON credentials
+      id: decode-google-service-account-json
       env:
-        ENCODED_STRING: ${{ inputs.SERVICE_ACCOUNT_JSON_BASE64 }}
+        CREDENTIALS_BASE64: ${{ inputs.google-service-account-json-base64 }}
+        CREDENTIALS_FILE_PATH: config/service-account-credentials.json
       run: |
-        echo "${ENCODED_STRING}" | base64 --decode > config/service-account-credentials.json
+        echo "${CREDENTIALS_BASE64}" | base64 --decode > ${CREDENTIALS_FILE_PATH}
+        echo "credentials-file-path=${CREDENTIALS_FILE_PATH}" >> "$GITHUB_OUTPUT"
       shell: bash
       working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
## Changes

- Fix inability to pass Google credentials between actions
  Previously, it was possible to decode a Google service account JSON but it was possible to get the file location of the resulting JSON file and supply it to the `govuk-one-login/mobile-android-pipelines/actions/publish-to-play-store` action.
- Refactor variables, inputs and outputs related to Google service account credentials and keystore

## Breaking changes

### Update action inputs

If you use the `govuk-one-login/mobile-android-pipelines/actions/publish-to-play-store` action:
- remove the `json-key-data` input (which accepted raw JSON data)
- add the `google-service-account-json` input (which now accepts a file path)

If you use the `govuk-one-login/mobile-android-pipelines/actions/retrieve-secrets` action:
- rename the `KEYSTORE_BASE64` input to `keystore-base64`
- rename the `SERVICE_ACCOUNT_JSON_BASE64` to `google-service-account-json-base64`

## Context

DCMAW-10665