### PR TITLE
refactor!: Remove kapt from default plugin set

### DIFF
--- a/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/android-lib-config.gradle.kts
+++ b/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/android-lib-config.gradle.kts
@@ -7,7 +7,6 @@ import uk.gov.pipelines.extensions.LintExtensions.configureLintOptions
 
 listOf(
     "com.android.library",
-    "kotlin-kapt",
     "org.jetbrains.kotlin.android",
     "uk.gov.pipelines.detekt-config",
     "uk.gov.pipelines.emulator-config",


### PR DESCRIPTION
## Changes

Remove kapt from the default set of plugins applied by `uk.gov.pipelines.android-lib-config` plugin.

## Breaking changes

If you rely on the presence of the kapt plugin and use the `uk.gov.pipelines.android-lib-config` plugin, you must add kapt to your project's `plugins` block:

```kt
plugins {
   kotlin("kapt")
}
```

## Context

DCMAW-10843

The plugin was originally introduced in
- https://github.com/govuk-one-login/mobile-android-pipelines/pull/6

However, not every project will need `kapt`. [Kapt is being phased out][kapt-to-ksp] in favour of KSP. Projects that can eliminate Kapt and use KSP will benefit from better build performance.

[kapt-to-ksp]: https://developer.android.com/build/migrate-to-ksp