### PR TITLE
feat!: Update default ktlint version to 1.5.0

### DIFF
--- a/buildLogic/gradle/libs.versions.toml
+++ b/buildLogic/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ hamcrest = "3.0"
 jacoco-tool = "0.8.12" # https://github.com/jacoco/jacoco/releases
 junit = "5.11.4" # https://github.com/junit-team/junit5/releases
 ktlint-gradle = "12.1.2" # https://github.com/JLLeitschuh/ktlint-gradle/releases
-ktlint-cli = "0.50.0" # https://github.com/pinterest/ktlint/releases
+ktlint-cli = "1.5.0" # https://github.com/pinterest/ktlint/releases
 kotlin-general = "2.1.0" # https://kotlinlang.org/docs/releases.html#release-details
 sonarqube-gradle = "6.0.1.5171" # https://github.com/SonarSource/sonar-scanner-gradle/releases
 

--- a/test-project/test-app/build.gradle.kts
+++ b/test-project/test-app/build.gradle.kts
@@ -30,3 +30,7 @@ dependencies {
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
 }
+
+ktlint {
+    version = "0.50.0"
+}

--- a/test-project/test-library/build.gradle.kts
+++ b/test-project/test-library/build.gradle.kts
@@ -21,3 +21,7 @@ dependencies {
     debugImplementation(libs.androidx.compose.ui.test.manifest)
     androidTestUtil(libs.androidx.test.orchestrator)
 }
+
+ktlint {
+    this.version = "0.50.0"
+}


### PR DESCRIPTION
## Changes

Update ktlint to version 1.5.0.

## Breaking changes

You may need to update your project's code style after updating to this version. You can do some of this automatically by running:

```sh
./gradle ktlintFormat
```

### Add new rule for Composable functions

If you use Composables, you may need to add the following `.editorconfig`:

```properties
# .editorconfig
[*.kt]
ktlint_function_naming_ignore_when_annotated_with=Composable
```

You can also [configure the ktlint extension directly](https://github.com/JLLeitschuh/ktlint-gradle?tab=readme-ov-file#configuration).

### Opt out of the upgrade

If you can't upgrade right away, you can manually downgrade the ktlint CLI version for your project:

```kts
// build.gradle.kts
ktlint {
    version = "0.50.0"
}
````




