### PR TITLE
ci: Fix deployment workflow

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -29,9 +29,6 @@ jobs:
         if: ${{ steps.versioning.outputs.current_version != steps.versioning.outputs.new_version }}
         uses: ./actions/publish-release-tag
 
-      - name: Maven publish
-        uses: ./mobile-android-pipelines/actions/maven-publish
-
       - name: Generate Changelog
         uses: ./actions/generate-and-upload-changelog
         with:


### PR DESCRIPTION
## Changes

- Trigger deployment workflow on push to main branch
- Add missing checkout step in deployment workflow
- Remove unnecessary maven publishing step (which would fail anyway)

## Context

[Example failed workflow run](https://github.com/govuk-one-login/mobile-android-pipelines/actions/runs/12888703799)

```
Error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/mobile-android-pipelines/mobile-android-pipelines/actions/setup-runner'. Did you forget to run actions/checkout before running your local action?
```