### PR TITLE
feat: enabling java module publishing

### DIFF
--- a/buildLogic/plugins/src/main/kotlin/uk/gov/config/AgpAwarePluginConfiguration.kt
+++ b/buildLogic/plugins/src/main/kotlin/uk/gov/config/AgpAwarePluginConfiguration.kt
@@ -14,6 +14,7 @@ import org.gradle.api.Project
 data class AgpAwarePluginConfiguration<ExtensionConfig : Any>(
     private val appPluginConfiguration: PluginConfiguration<ExtensionConfig>,
     private val libraryPluginConfiguration: PluginConfiguration<ExtensionConfig>,
+    private val javaModulePluginConfiguration: PluginConfiguration<ExtensionConfig>,
 ) : PluginConfiguration<ExtensionConfig> {
     override fun applyConfig(
         project: Project,
@@ -27,6 +28,10 @@ data class AgpAwarePluginConfiguration<ExtensionConfig : Any>(
             project.pluginManager.hasPlugin("com.android.library")
         ) {
             libraryPluginConfiguration.applyConfig(project, extension)
+        } else if (
+            project.pluginManager.hasPlugin("java-library")
+        ) {
+            javaModulePluginConfiguration.applyConfig(project, extension)
         }
     }
 }

--- a/buildLogic/plugins/src/main/kotlin/uk/gov/publishing/defaults/MavenPublishingConfigDefaults.kt
+++ b/buildLogic/plugins/src/main/kotlin/uk/gov/publishing/defaults/MavenPublishingConfigDefaults.kt
@@ -51,6 +51,43 @@ object MavenPublishingConfigDefaults {
             }
         }
 
+    private val javaModuleLibConfig =
+        PluginConfiguration {
+                project: Project,
+                extension: MavenPublishingConfigExtension,
+            ->
+
+            project.configure<PublishingExtension> {
+                configureJavaModuleMavenPublishing(project, extension)
+            }
+        }
+
+    private fun PublishingExtension.configureJavaModuleMavenPublishing(
+        project: Project,
+        extension: MavenPublishingConfigExtension,
+    ) {
+        repositories {
+            configureMavenRepositoriesToPublishTo(project)
+        }
+        publications {
+            register<MavenPublication>("default") {
+                this.groupId = extension.mavenConfigBlock.artifactGroupId.get()
+                this.artifactId = project.name
+                this.version = project.versionName
+
+                project.afterEvaluate {
+                    from(project.components["java"])
+                    withBuildIdentifier()
+                }
+                pom {
+                    defaultPomSetup(
+                        extension.mavenConfigBlock,
+                    )
+                }
+            }
+        }
+    }
+
     /**
      * Declares the repositories to utilise for the [PublishingExtension.repositories] block.
      *
@@ -134,6 +171,7 @@ object MavenPublishingConfigDefaults {
         AgpAwarePluginConfiguration(
             appPluginConfiguration = nothing,
             libraryPluginConfiguration = defaultLibConfig,
+            javaModulePluginConfiguration = javaModuleLibConfig,
         )
 
     /**


### PR DESCRIPTION
- enable publishing of pure java/kotlin modules
- tested in https://github.com/govuk-one-login/mobile-android-cri-orchestrator/pull/85