### PR TITLE
ci: Fix permissions for deployment workflow

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -10,6 +10,8 @@ jobs:
   deploy-release:
     name: Deploy release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout codebase
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
## Changes

Add correct permissions to the deployment job which pushes a new Git tags to this repository.

## Context

[Workflow] fails with the following error:
```
Run ./actions/publish-release-tag
Run git push --follow-tags && git push --tags
remote: Permission to govuk-one-login/mobile-android-pipelines.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/govuk-one-login/mobile-android-pipelines/': The requested URL returned error: 403
Error: Process completed with exit code 128.
```

[Workflow]: https://github.com/govuk-one-login/mobile-android-pipelines/actions/runs/12994646851/job/36239569933