### PR TITLE
fix: clean workspace in deploy-release workflow

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -39,3 +39,5 @@ jobs:
 
       - name: Clean workspace
         uses: ./actions/clean-workspace
+        with: 
+          pipelines-directory: .


### PR DESCRIPTION
- specify `pipelines-directory` in last `clean-workspace`  step

Previously, workflow was failing with:
![image](https://github.com/user-attachments/assets/74a5dc0e-b60c-41a3-a08e-cb7e686dc54e)
