### PR TITLE
refactor: Replace deprecated function

### DIFF
--- a/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/extensions/BaseExtensions.kt
+++ b/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/extensions/BaseExtensions.kt
@@ -6,7 +6,6 @@ import com.android.build.gradle.internal.tasks.ManagedDeviceInstrumentationTestT
 import com.android.build.gradle.internal.tasks.ManagedDeviceSetupTask
 import org.gradle.api.Project
 import org.gradle.api.tasks.Exec
-import org.gradle.configurationcache.extensions.capitalized
 import org.gradle.kotlin.dsl.extra
 import org.gradle.kotlin.dsl.invoke
 import org.gradle.kotlin.dsl.maybeCreate
@@ -17,6 +16,7 @@ import uk.gov.pipelines.config.buildLogicDir
 import uk.gov.pipelines.emulator.SystemImageSource
 import uk.gov.pipelines.extensions.ProjectExtensions.versionCode
 import uk.gov.pipelines.extensions.ProjectExtensions.versionName
+import uk.gov.pipelines.extensions.StringExtensions.capitaliseFirstCharacter
 import uk.gov.pipelines.extensions.StringExtensions.proseToUpperCamelCase
 import java.io.File
 
@@ -95,7 +95,7 @@ object BaseExtensions {
         val systemImageSourceTaskSegment = source.sanitise()
 
         return systemImageSourceTaskSegment +
-            "${hardwareProfileTaskSegment.capitalized()}Api$apiLevel"
+            "${hardwareProfileTaskSegment.capitaliseFirstCharacter()}Api$apiLevel"
     }
 
     /**

--- a/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/extensions/LibraryVariantExt.kt
+++ b/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/extensions/LibraryVariantExt.kt
@@ -3,7 +3,7 @@ package uk.gov.pipelines.extensions
 import com.android.build.gradle.api.ApplicationVariant
 import com.android.build.gradle.api.LibraryVariant
 import org.gradle.api.Project
-import org.gradle.configurationcache.extensions.capitalized
+import uk.gov.pipelines.extensions.StringExtensions.capitaliseFirstCharacter
 import uk.gov.pipelines.filetree.fetcher.FileTreesFetcher
 import uk.gov.pipelines.filetree.fetcher.JavaCompileFileTreeFetcher
 import uk.gov.pipelines.filetree.fetcher.KotlinCompileFileTreeFetcher
@@ -14,7 +14,7 @@ import uk.gov.pipelines.jacoco.tasks.JacocoUnitTestTaskGenerator
 
 fun LibraryVariant.generateDebugJacocoTasks(project: Project) {
     val capitalisedFlavorName =
-        flavorName?.capitalized() ?: error(
+        flavorName?.capitaliseFirstCharacter() ?: error(
             "The library variant has no flavor name!",
         )
     generateJacocoTasks(
@@ -27,7 +27,7 @@ fun LibraryVariant.generateDebugJacocoTasks(project: Project) {
 
 fun ApplicationVariant.generateDebugJacocoTasks(project: Project) {
     val capitalisedFlavorName =
-        flavorName?.capitalized() ?: error(
+        flavorName?.capitaliseFirstCharacter() ?: error(
             "The application variant has no flavor name!",
         )
     generateJacocoTasks(

--- a/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/extensions/StringExtensions.kt
+++ b/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/extensions/StringExtensions.kt
@@ -29,7 +29,7 @@ object StringExtensions {
                 .capitaliseFirstCharacter()
         }
 
-    private fun String.capitaliseFirstCharacter() =
+    internal fun String.capitaliseFirstCharacter() =
         this.replaceFirstChar { char ->
             if (char.isLowerCase()) {
                 char.titlecase(Locale.getDefault())

--- a/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/filetree/fetcher/BaseFileTreeFetcher.kt
+++ b/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/filetree/fetcher/BaseFileTreeFetcher.kt
@@ -5,8 +5,8 @@ import org.gradle.api.Task
 import org.gradle.api.file.FileTree
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.util.PatternSet
-import org.gradle.configurationcache.extensions.capitalized
 import uk.gov.pipelines.extensions.ProjectExtensions.debugLog
+import uk.gov.pipelines.extensions.StringExtensions.capitaliseFirstCharacter
 
 /**
  * Partial implementation for obtaining a [FileTree].
@@ -28,7 +28,7 @@ abstract class BaseFileTreeFetcher(
     /**
      * The TitleCase representation of the Android app or library's build variant.
      */
-    protected val capitalisedVariantName = variant.capitalized()
+    protected val capitalisedVariantName = variant.capitaliseFirstCharacter()
 
     /**
      * Obtain the original [FileTree] for an implementation. This has no filtration on the object.

--- a/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/jacoco-app-config.gradle.kts
+++ b/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/jacoco-app-config.gradle.kts
@@ -5,9 +5,9 @@ import com.android.build.gradle.AppExtension
 import com.android.build.gradle.internal.coverage.JacocoReportTask
 import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
 import com.android.build.gradle.internal.tasks.ManagedDeviceInstrumentationTestTask
-import org.gradle.configurationcache.extensions.capitalized
 import uk.gov.pipelines.extensions.LibraryExtensionExt.decorateExtensionWithJacoco
 import uk.gov.pipelines.extensions.ProjectExtensions.debugLog
+import uk.gov.pipelines.extensions.StringExtensions.capitaliseFirstCharacter
 import uk.gov.pipelines.extensions.generateDebugJacocoTasks
 
 project.plugins.apply("uk.gov.pipelines.jacoco-common-config")
@@ -35,7 +35,7 @@ project.configure<ApplicationAndroidComponentsExtension> {
                 it.name.contains(variant.name, ignoreCase = true)
             }.forEach { instrumentationTestTask ->
                 val coverageReportTaskName =
-                    "createManagedDevice${variant.name.capitalized()}AndroidTestCoverageReport"
+                    "createManagedDevice${variant.name.capitaliseFirstCharacter()}AndroidTestCoverageReport"
                 val androidCoverageReportTask =
                     project.tasks.named(
                         coverageReportTaskName,

--- a/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/jacoco/tasks/BaseJacocoTaskGenerator.kt
+++ b/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/jacoco/tasks/BaseJacocoTaskGenerator.kt
@@ -1,8 +1,8 @@
 package uk.gov.pipelines.jacoco.tasks
 
 import org.gradle.api.Project
-import org.gradle.configurationcache.extensions.capitalized
 import org.gradle.testing.jacoco.tasks.JacocoReport
+import uk.gov.pipelines.extensions.StringExtensions.capitaliseFirstCharacter
 import uk.gov.pipelines.jacoco.config.JacocoCustomConfig
 
 /**
@@ -25,7 +25,7 @@ abstract class BaseJacocoTaskGenerator(
     /**
      * TitleCase representation of the Android app or library's build variant.
      */
-    protected val capitalisedVariantName: String = variant.capitalized()
+    protected val capitalisedVariantName: String = variant.capitaliseFirstCharacter()
 
     /**
      * The name of the Android System Development Kit (SDK)'s implementation of Jacoco test

--- a/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/jacoco/tasks/JacocoConnectedTestTaskGenerator.kt
+++ b/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/jacoco/tasks/JacocoConnectedTestTaskGenerator.kt
@@ -1,8 +1,8 @@
 package uk.gov.pipelines.jacoco.tasks
 
 import org.gradle.api.Project
-import org.gradle.configurationcache.extensions.capitalized
 import uk.gov.pipelines.Filters
+import uk.gov.pipelines.extensions.StringExtensions.capitaliseFirstCharacter
 import uk.gov.pipelines.filetree.fetcher.FileTreeFetcher
 import uk.gov.pipelines.jacoco.config.JacocoConnectedTestConfig
 import uk.gov.pipelines.jacoco.config.JacocoCustomConfig
@@ -21,12 +21,12 @@ class JacocoConnectedTestTaskGenerator(
     private val project: Project,
     private val classDirectoriesFetcher: FileTreeFetcher,
     variant: String,
-    name: String = "jacoco${variant.capitalized()}ConnectedTestReport",
+    name: String = "jacoco${variant.capitaliseFirstCharacter()}ConnectedTestReport",
     configuration: JacocoCustomConfig =
         JacocoConnectedTestConfig(
             project,
             classDirectoriesFetcher,
-            variant.capitalized(),
+            variant.capitaliseFirstCharacter(),
             name,
         ),
 ) : BaseJacocoTaskGenerator(

--- a/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/jacoco/tasks/JacocoManagedDeviceTaskGenerator.kt
+++ b/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/jacoco/tasks/JacocoManagedDeviceTaskGenerator.kt
@@ -2,8 +2,8 @@ package uk.gov.pipelines.jacoco.tasks
 
 import com.android.build.gradle.internal.tasks.ManagedDeviceInstrumentationTestTask
 import org.gradle.api.Project
-import org.gradle.configurationcache.extensions.capitalized
 import uk.gov.pipelines.Filters
+import uk.gov.pipelines.extensions.StringExtensions.capitaliseFirstCharacter
 import uk.gov.pipelines.filetree.fetcher.FileTreeFetcher
 import uk.gov.pipelines.jacoco.config.JacocoManagedDeviceConfig
 
@@ -19,7 +19,7 @@ class JacocoManagedDeviceTaskGenerator(
             )
 
         testTasks.map { testTask ->
-            val jacocoTaskName = "jacoco${testTask.name.capitalized()}Report"
+            val jacocoTaskName = "jacoco${testTask.name.capitaliseFirstCharacter()}Report"
             testTask to
                 JacocoManagedDeviceConfig(
                     project = project,

--- a/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/jacoco/tasks/JacocoUnitTestTaskGenerator.kt
+++ b/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/jacoco/tasks/JacocoUnitTestTaskGenerator.kt
@@ -1,8 +1,8 @@
 package uk.gov.pipelines.jacoco.tasks
 
 import org.gradle.api.Project
-import org.gradle.configurationcache.extensions.capitalized
 import uk.gov.pipelines.Filters
+import uk.gov.pipelines.extensions.StringExtensions.capitaliseFirstCharacter
 import uk.gov.pipelines.filetree.fetcher.FileTreeFetcher
 import uk.gov.pipelines.jacoco.config.JacocoCustomConfig
 import uk.gov.pipelines.jacoco.config.JacocoUnitTestConfig
@@ -21,12 +21,12 @@ class JacocoUnitTestTaskGenerator(
     private val project: Project,
     private val classDirectoriesFetcher: FileTreeFetcher,
     variant: String,
-    private val name: String = "jacoco${variant.capitalized()}UnitTestReport",
+    private val name: String = "jacoco${variant.capitaliseFirstCharacter()}UnitTestReport",
     configuration: JacocoCustomConfig =
         JacocoUnitTestConfig(
             project,
             classDirectoriesFetcher,
-            variant.capitalized(),
+            variant.capitaliseFirstCharacter(),
             name,
         ),
 ) : BaseJacocoTaskGenerator(


### PR DESCRIPTION
## Changes

Remove calls to deprecated `String.capitalized()` function.

## Context

Fixes warnings that pollute logs for dependent projects ([example build]).

```
'capitalized(): String' is deprecated. This was never intended as a public API.
```

[example build]: https://github.com/govuk-one-login/mobile-android-cri-orchestrator/actions/runs/13011988267/job/36291664718?pr=95