### PR TITLE
ci: Fix version tag deployment

### DIFF
--- a/cog.toml
+++ b/cog.toml
@@ -1,3 +1,3 @@
 tag_prefix = "v"
 ignore_merge_commits = true
-
+disable_bump_commit = true


### PR DESCRIPTION
## Changes

Add configuration to prevent the versioning tool from committing to the main branch, behaviour which is not compatible with the deployment workflow.

## Context

The version tag deployment is currently failing in this repository.

https://github.com/govuk-one-login/mobile-android-pipelines/actions/runs/13008746989/job/36281430951

```
 remote: - Changes must be made through a pull request.     
```

By default, when Cocogitto bumps the version, it creates a new commit. However this will result in a rejected push. We only need to create and push a new tag new version tag.

