### PR TITLE
refactor: Install cocogitto using official action

### DIFF
--- a/actions/setup-runner/action.yml
+++ b/actions/setup-runner/action.yml
@@ -34,11 +34,14 @@ runs:
       shell: bash
       if: runner.os == 'Linux'
 
-    - name: Install brew dependencies
-      run: |
-        brew install vale
-        brew install cocogitto
+    - name: Install vale
+      run: brew install vale
       shell: bash
+
+    - name: Install cocogitto
+      uses: cocogitto/cocogitto-action@ed62593c499c2d7697bb0177213946f1e2634119 # v3.10
+      with:
+        check: false
 
     - name: Install KVM hardware acceleration Dependencies
       # see docs: https://help.ubuntu.com/community/KVM/Installation


### PR DESCRIPTION
## Changes

Install Cocogitto using the official action.

## Context

Using this action makes the installation immediate because, internally it uses caching.