### PR TITLE
chore: Add ADR term to dictionary

### DIFF
--- a/buildLogic/config/vale/styles/config/vocabularies/Base/accept.txt
+++ b/buildLogic/config/vale/styles/config/vocabularies/Base/accept.txt
@@ -6,6 +6,7 @@
 (?i)JIRA
 (?i)Zsh
 (?i)ktlint
+ADR(s)?
 APIs
 DAD
 DCMAW


### PR DESCRIPTION
## Changes

Add "ADR" which is short for Architectural Design Record to the vale dictionary.

## Context

- https://github.com/govuk-one-login/mobile-android-cri-orchestrator/pull/128