### PR TITLE
fix: Remove environment variable usage

### DIFF
--- a/buildLogic/plugins/src/main/kotlin/uk/gov/publishing/defaults/MavenPublishingConfigDefaults.kt
+++ b/buildLogic/plugins/src/main/kotlin/uk/gov/publishing/defaults/MavenPublishingConfigDefaults.kt
@@ -151,13 +151,13 @@ object MavenPublishingConfigDefaults {
                     "https://maven.pkg.github.com/govuk-one-login/$githubRepositoryName",
                 )
             credentials {
-                username = System.getenv("GITHUB_ACTOR")
-                password = System.getenv("GITHUB_TOKEN")
+                username = project.providers.gradleProperty("gpr.user").get()
+                password = project.providers.gradleProperty("gpr.token").get()
             }
         }
         maven {
             name = "localBuild"
-            url = project.uri("${project.buildDir}/repo")
+            url = project.uri("${project.layout.buildDirectory}/repo")
         }
     }
 


### PR DESCRIPTION
The plugins are using the gradle properties gpr.user and gpr.token for credential access Update MavenPublishingConfigDefaults to match this pattern

Resolves: 9570