### PR TITLE
feat: Add JUnit and Robolectric to dictionary

### DIFF
--- a/buildLogic/config/vale/styles/config/vocabularies/Base/accept.txt
+++ b/buildLogic/config/vale/styles/config/vocabularies/Base/accept.txt
@@ -15,6 +15,7 @@ GNU
 GPG
 JDK
 JRE
+JUnit
 LFS
 MAM
 MRZes
@@ -22,6 +23,7 @@ NIST
 OAuth
 RSPEC
 ReadID
+Robolectric
 VIZes
 [Aa]ndroid
 [Bb]io[Tt]oken


### PR DESCRIPTION
## Changes

Add JUnit and Robolectric to vale accept list.

## Context

- https://github.com/govuk-one-login/mobile-android-cri-orchestrator/pull/131