### PR TITLE
chore: disable AndroidGradlePluginVersion lint rule to unblock pull requests

### DIFF
--- a/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/extensions/LintExtensions.kt
+++ b/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/extensions/LintExtensions.kt
@@ -25,6 +25,7 @@ object LintExtensions {
                     // Manage dependency updates using Dependabot
                     // https://gds-way.digital.cabinet-office.gov.uk/standards/tracking-dependencies.html
                     "NewerVersionAvailable",
+                    "AndroidGradlePluginVersion",
                 ),
             )
             explainIssues = true


### PR DESCRIPTION
Disable Gradle Plugin Version rule, which is causing CI builds to fail:
https://github.com/govuk-one-login/mobile-android-ui/actions/runs/13563951869