### PR TITLE
build: DCMAW-11849: Android Pipelines: Set up runner action fails to install brew dependencies

### DIFF
--- a/actions/setup-runner/action.yml
+++ b/actions/setup-runner/action.yml
@@ -93,5 +93,5 @@ runs:
 
     - name: Install project defined homebrew dependencies
       run: |
-        if [ -f Brewfile ]; then brew bundle --no-lock; fi
+        if [ -f Brewfile ]; then brew bundle; fi
       shell: bash

--- a/scripts/firstTimeDevSetup
+++ b/scripts/firstTimeDevSetup
@@ -54,7 +54,7 @@ function installHomebrewIfNecessary {
 # Installs all dependencies declared within the code base.
 function installProjectDependencies {
   echo "## Installing Brewfile dependencies... ##"
-  brew bundle --file="${GIT_ROOT}/Brewfile" --no-lock
+  brew bundle --file="${GIT_ROOT}/Brewfile"
 }
 
 ## SCRIPT STARTS HERE ##

--- a/scripts/sonar/verifyPath
+++ b/scripts/sonar/verifyPath
@@ -6,6 +6,6 @@ set -o errexit
 # Start sonar server
 echo "- Ensuring that all commands are available on the PATH..."
 if ! which "sonar"; then
-  echo "  - Cannot find ${TERMINAL_COMMAND} on the PATH! Have you performed 'brew bundle --no-lock'?"
+  echo "  - Cannot find ${TERMINAL_COMMAND} on the PATH! Have you performed 'brew bundle'?"
   exit 11
 fi


### PR DESCRIPTION
- references to "--no-lock" has been removed

`--no-lock` is no longer available in Brew bundler.

This command previously had no action, see details here:
https://github.com/Homebrew/homebrew-bundle/pull/1630/files