### PR TITLE
fix: exclude meta inf

### DIFF
--- a/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/extensions/BaseExtensions.kt
+++ b/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/extensions/BaseExtensions.kt
@@ -140,6 +140,7 @@ object BaseExtensions {
                 resources.excludes += "META-INF/LICENSE-W3C-TEST"
                 resources.excludes += "META-INF/DEPENDENCIES"
                 resources.excludes += "*.proto"
+                resources.excludes += "META-INF/versions/9/OSGI-INF/MANIFEST.MF"
             }
 
             testOptions {


### PR DESCRIPTION
Fix issue with build on CRI orchestrator after importing the id check SDK

https://github.com/govuk-one-login/mobile-android-cri-orchestrator/actions/runs/13969006232/job/39105990238