### PR TITLE
fix: Ensure library sources can be resolved in IDE

### DIFF
--- a/buildLogic/plugins/src/main/kotlin/uk/gov/publishing/defaults/MavenPublishingConfigDefaults.kt
+++ b/buildLogic/plugins/src/main/kotlin/uk/gov/publishing/defaults/MavenPublishingConfigDefaults.kt
@@ -51,7 +51,7 @@ object MavenPublishingConfigDefaults {
                 configureMavenPublishing(
                     project = project,
                     extension = extension,
-                    component = "default",
+                    component = "release",
                 )
             }
         }
@@ -97,7 +97,7 @@ object MavenPublishingConfigDefaults {
                 this.version = project.versionName
 
                 project.afterEvaluate {
-                    from(project.components["release"])
+                    from(project.components[component])
                     withBuildIdentifier()
                 }
                 pom {


### PR DESCRIPTION
## Changes

Ensure library sources can be resolved in IDE.

## Context

Android Studio is [not yet fully compatible][google-issue] with variant aware publications and can't resolve the sources jars. 

It is possible to workaround this by manually publishing artifacts in a way that _is_ compatible (see [Publishing a variant-aware Android library with its sources][workaround-article]). But the workaround needs the default publication format to be manually adjusted. Given this issue should eventually be fixed upstream, I decided it wasn't worth the maintenace burden.

Instead, this fix reverts from multi-variant publishing to single-variant publishing, which seems to be in line with what other Android libraries are doing.

The limitation of this approach is that libraries will only be published using the release configuration. Debug-only behaviour will be unavailable without building and publishing the library locally.

[DCMAW-10162](https://govukverify.atlassian.net/browse/DCMAW-10162)
[DCMAW-11827](https://govukverify.atlassian.net/browse/DCMAW-11827)

[google-issue]: https://issuetracker.google.com/u/0/issues/197636221
[workaround-article]: https://medium.com/glovo-engineering/publishing-a-variant-aware-android-library-with-its-sources-c61387323963

[DCMAW-10162]: https://govukverify.atlassian.net/browse/DCMAW-10162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DCMAW-11827]: https://govukverify.atlassian.net/browse/DCMAW-11827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ