### PR TITLE
feat: Disable gradle caching and allow functionality to enable it

### DIFF
--- a/actions/setup-runner/action.yml
+++ b/actions/setup-runner/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: 'The version of gradle for the "gradle/gradle-build-action step.'
     required: false
     default: 'wrapper'
+  gradle-cache-enabled:
+    description: 'Allowing for gradle cache on the runner'
+    required: false
+    default: 'false'
 runs:
   using: "composite"
   steps:
@@ -82,6 +86,7 @@ runs:
       uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244 # v4.3.1
       with:
         gradle-version: ${{ inputs.gradle-version }}
+        cache-disabled: ${{ inputs.gradle-cache-enabled == 'true' }}
 
     - name: Setup Android SDK
       uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.2

--- a/actions/setup-runner/action.yml
+++ b/actions/setup-runner/action.yml
@@ -9,10 +9,10 @@ inputs:
     description: 'The version of gradle for the "gradle/gradle-build-action step.'
     required: false
     default: 'wrapper'
-  gradle-cache-enabled:
+  gradle-cache-disabled:
     description: 'Allowing for gradle cache on the runner'
     required: false
-    default: 'false'
+    default: 'true'
 runs:
   using: "composite"
   steps:
@@ -86,7 +86,7 @@ runs:
       uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244 # v4.3.1
       with:
         gradle-version: ${{ inputs.gradle-version }}
-        cache-disabled: ${{ inputs.gradle-cache-enabled == 'true' }}
+        cache-disabled: ${{ inputs.gradle-cache-disabled == 'true' }}
 
     - name: Setup Android SDK
       uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.2


### PR DESCRIPTION
- disable gradle cache and add functionality for the action to allow configuration from the consumer
- the default is set to false
*This can only be configured if action is implemented manually, using the default pipeline workflow is automatically set to disabled*