### PR TITLE
fix: Fix conflicts when publishing tags

### DIFF
--- a/actions/publish-release-tag/action.yml
+++ b/actions/publish-release-tag/action.yml
@@ -6,5 +6,5 @@ runs:
   steps:
     - name: Publish the release tag
       run: |
-        git push --follow-tags && git push --tags
+        git push --tags
       shell: bash


### PR DESCRIPTION
## Changes

Remove command that pushes branches during the Github actions step that publishes tags.

## Context

Fixes a problem when trying to publish tags from a given commit after a newer commit has been pushed to the currently checked out branch.

This can happen when the Github action runs on the main branch and two PRs are merged in quick succession. The first release will fail to push because there are newer commits on main.

```
--follow-tags
    Push all the refs that would be pushed without this option, and also push annotated tags ...

--tags
    All refs under refs/tags are pushed, in addition to refspecs explicitly listed on the command line.
````
