### PR TITLE
build: DCMAW-14270 upgrade API level 35

### DIFF
--- a/buildLogic/plugins/src/testFixtures/kotlin/uk/gov/pipelines/extras/FakeApkConfig.kt
+++ b/buildLogic/plugins/src/testFixtures/kotlin/uk/gov/pipelines/extras/FakeApkConfig.kt
@@ -8,7 +8,7 @@ class FakeApkConfig : ApkConfig {
     override val sdkVersions =
         object : ApkConfig.SdkVersions {
             override val minimum = 29
-            override val target = 34
+            override val target = 35
             override val compile = 35
         }
 }

--- a/test-project/build.gradle.kts
+++ b/test-project/build.gradle.kts
@@ -35,7 +35,7 @@ val apkConfig by rootProject.extra(
         override val debugVersion: String = "DEBUG_VERSION"
         override val sdkVersions = object: ApkConfig.SdkVersions {
             override val minimum = 29
-            override val target = 34
+            override val target = 35
             override val compile = 35
         }
     }


### PR DESCRIPTION
# Changes
- Upgrading the target API level to API 35 in line with Google's requirement 
<img width="374" height="274" alt="image" src="https://github.com/user-attachments/assets/f29ecd05-833d-4ed4-aba7-bdb4607d0bdc" />

## Evidence
| Evidence app launches |
| - |
| ![Pipelines](https://github.com/user-attachments/assets/aca9dcc0-22f0-43a5-b191-261c34a62cf0) |