### PR TITLE
perf: leverage pre-installed runner tools instead of downloading

### DIFF
--- a/actions/common-prerequisites/action.yml
+++ b/actions/common-prerequisites/action.yml
@@ -5,15 +5,20 @@ inputs:
     description: 'The Java Development Kit (JDK) version to use'
     required: false
     default: '21'
+  install-vale:
+    description: 'Install vale prose linter'
+    required: false
+    default: 'true'
 
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-      with:
-        distribution: 'oracle'
-        java-version: ${{ inputs.jdk-version }}
-        cache: gradle
+    - name: Set up JDK ${{ inputs.jdk-version }}
+      shell: bash
+      run: |
+        JAVA_HOME_VAR="JAVA_HOME_${{ inputs.jdk-version }}_X64"
+        echo "JAVA_HOME=${!JAVA_HOME_VAR}" >> $GITHUB_ENV
+        echo "${!JAVA_HOME_VAR}/bin" >> $GITHUB_PATH
 
     - name: Install Cocogitto
       uses: cocogitto/cocogitto-action@52d0023b4396897f1815648e553db2ab8d782f3a # v4.2.0
@@ -21,9 +26,12 @@ runs:
         command: help # A no-op command
 
     - name: Set up Homebrew
-      id: set-up-homebrew
-      uses: Homebrew/actions/setup-homebrew@master
+      shell: bash
+      run: |
+        echo "/home/linuxbrew/.linuxbrew/bin" >> $GITHUB_PATH
+        echo "/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
 
     - name: Install Vale
+      if: inputs.install-vale == 'true'
       run: brew install vale
       shell: bash

--- a/actions/setup-runner/action.yml
+++ b/actions/setup-runner/action.yml
@@ -20,26 +20,18 @@ runs:
       shell: bash
       run: echo "/usr/local/bin" >> $GITHUB_PATH
 
-    - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-      with:
-        distribution: 'oracle'
-        java-version: ${{ inputs.jdk-version }}
-
-    - name: Add JAVA_HOME globally
-      env:
-        JDK_VERSION: ${{ inputs.jdk-version }}
-      run: |
-        echo "JAVA_HOME=$(/usr/libexec/java_home --version ${JDK_VERSION})" >> $GITHUB_ENV
+    - name: Set up JDK ${{ inputs.jdk-version }}
       shell: bash
+      run: |
+        JAVA_HOME_VAR="JAVA_HOME_${{ inputs.jdk-version }}_X64"
+        echo "JAVA_HOME=${!JAVA_HOME_VAR}" >> $GITHUB_ENV
+        echo "${!JAVA_HOME_VAR}/bin" >> $GITHUB_PATH
 
     - name: Set up Homebrew
-      id: set-up-homebrew
-      # Didn't appear to use versioning!
-      uses: Homebrew/actions/setup-homebrew@a7a36215df86859f163fbb774ebe0cecf9ec8547
-
-    - name: Install vale
-      run: brew install vale
       shell: bash
+      run: |
+        echo "/home/linuxbrew/.linuxbrew/bin" >> $GITHUB_PATH
+        echo "/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
 
     - name: Install cocogitto
       uses: cocogitto/cocogitto-action@52d0023b4396897f1815648e553db2ab8d782f3a # v4.2.0
@@ -90,8 +82,3 @@ runs:
 
     - name: Setup Android SDK
       uses: android-actions/setup-android@651bceb6f9ca583f16b8d75b62c36ded2ae6fc9c # v4.0.0
-
-    - name: Update Android SDK Manager
-      run: |
-        sdkmanager --update
-      shell: bash


### PR DESCRIPTION
# Perf: Leverage pre-installed runner tools instead of downloading

## Changes

### Use pre-installed JDK (setup-runner and common-prerequisites)
- Replaced `actions/setup-java` (which downloads Oracle JDK) with a direct reference to the pre-installed JDK via `JAVA_HOME_<version>_X64` environment variable
- Also fixes the broken `/usr/libexec/java_home` call which is a macOS command that fails on Linux runners
- **Saves ~4s per job**

### Use pre-installed Homebrew (setup-runner and common-prerequisites)
- Replaced `Homebrew/actions/setup-homebrew` (which fetches and updates the entire Homebrew repo) with adding linuxbrew to `GITHUB_PATH`
- Homebrew is already pre-installed on Ubuntu runners, just not on PATH
- **Saves ~8s per job**

### Remove redundant `sdkmanager --update` (setup-runner)
- Removed `sdkmanager --update` as the runner already has up-to-date SDK components
- Kept `setup-android` as it ensures `ANDROID_HOME` and SDK tools (including `avdmanager`) are on PATH, which is required by the `emulator-config` Gradle plugin
- **Saves ~2s per job using setup-runner**

### Remove vale from setup-runner, make opt-in on common-prerequisites
- Removed vale from `setup-runner` entirely
- Added `install-vale` parameter to `common-prerequisites` (default `true` for backwards compatibility)
- Consumers that do not need vale can pass `install-vale: false`
- **Saves ~29s per job that opts out of vale**

## Estimated time savings
- Jobs using `common-prerequisites` (with `install-vale: false`): **~41s** (JDK + Homebrew + vale)
- Jobs using `common-prerequisites` (default): **~12s** (JDK + Homebrew)
- Jobs using `setup-runner`: **~43s** (JDK + Homebrew + vale + sdkmanager)
- Non-emulator jobs that previously used `setup-runner` and switch to `common-prerequisites`: **~80s** (above + KVM ~37s)

## Why
These changes eliminate unnecessary downloads and updates during CI setup. The Ubuntu runner images already ship with these tools. `setup-runner` is now reserved for emulator jobs (includes KVM, Gradle, Android SDK), while `common-prerequisites` provides a lightweight setup for everything else.

This has enabled us to take ~3 min off our end-to-end pipelines in the sharing team: https://github.com/govuk-one-login/mobile-credential-sharing-android/pull/315


## Checklist

- [x] Check against acceptance criteria
- [x] Self-review code