### PR TITLE
build: Update `gradle/actions/setup-gradle` from 6.0.1 to 6.1.0

### DIFF
--- a/actions/setup-runner/action.yml
+++ b/actions/setup-runner/action.yml
@@ -75,7 +75,7 @@ runs:
 
     - name: Setup Gradle
       id: setupGradle
-      uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v6.0.1
+      uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
       with:
         gradle-version: ${{ inputs.gradle-version }}
         cache-disabled: ${{ inputs.gradle-cache-disabled == 'true' }}

--- a/actions/setup-runner/action.yml
+++ b/actions/setup-runner/action.yml
@@ -79,6 +79,7 @@ runs:
       with:
         gradle-version: ${{ inputs.gradle-version }}
         cache-disabled: ${{ inputs.gradle-cache-disabled == 'true' }}
+        cache-provider: basic
 
     - name: Setup Android SDK
       uses: android-actions/setup-android@651bceb6f9ca583f16b8d75b62c36ded2ae6fc9c # v4.0.0


### PR DESCRIPTION
## Context

https://github.com/gradle/actions/releases/tag/v6.1.0

DCMAW-19663

Update for the new path based caching support which takes into account `gradle/*.versions.toml` files when calculating the cache keys.
