### PR TITLE
build: add dependency submission action

### DIFF
--- a/.github/workflows/check-test-project.yml
+++ b/.github/workflows/check-test-project.yml
@@ -70,6 +70,29 @@ jobs:
         with:
           artifact-name: test-project-instrumentation-test-coverage
 
+  dependency-submission:
+    name: Dependency submission
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+
+      - name: 'Checkout codebase'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Clean runner
+        uses: ./actions/clean-runner-fast
+
+      - name: Setup runner
+        uses: ./actions/common-prerequisites
+
+      - name: Generate and submit dependency graph
+        uses: ./actions/dependency-submission
+        with:
+          additional-arguments: --project-dir test-project
+
   sonar-scan:
     name: Scan with Sonar
     runs-on: ubuntu-latest

--- a/.github/workflows/check-test-project.yml
+++ b/.github/workflows/check-test-project.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Generate and submit dependency graph
         uses: ./actions/dependency-submission
         with:
-          additional-arguments: --project-dir test-project
+          build-root-directory: test-project
 
   sonar-scan:
     name: Scan with Sonar

--- a/actions/dependency-submission/action.yml
+++ b/actions/dependency-submission/action.yml
@@ -1,0 +1,16 @@
+name: 'Dependency Submission'
+description: 'Generate and submit the dependency graph'
+
+inputs:
+  additional-arguments:
+    description: 'Additional arguments to pass to the Gradle dependency submission action'
+    required: false
+    default: ''
+
+runs:
+  using: "composite"
+  steps:
+    - name: Generate and submit dependency graph
+      uses: gradle/actions/dependency-submission@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+      with:
+        additional-arguments: ${{ inputs.additional-arguments }}

--- a/actions/dependency-submission/action.yml
+++ b/actions/dependency-submission/action.yml
@@ -2,6 +2,10 @@ name: 'Dependency Submission'
 description: 'Generate and submit the dependency graph'
 
 inputs:
+  build-root-directory:
+    description: 'Path to the root directory of the Gradle project. Defaults to the repository root.'
+    required: false
+    default: ''
   additional-arguments:
     description: 'Additional arguments to pass to the Gradle dependency submission action'
     required: false
@@ -13,4 +17,5 @@ runs:
     - name: Generate and submit dependency graph
       uses: gradle/actions/dependency-submission@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       with:
+        build-root-directory: ${{ inputs.build-root-directory }}
         additional-arguments: ${{ inputs.additional-arguments }}


### PR DESCRIPTION
### Context

Creating an action that can be used to generate and submit a full dependency graph to Github. This will allow Github to check for vulnerabilities of transitive dependencies