### PR TITLE
ci: Allow dependabot updates to trigger releases

### DIFF
--- a/cog.toml
+++ b/cog.toml
@@ -1,3 +1,6 @@
 tag_prefix = "v"
 ignore_merge_commits = true
 disable_bump_commit = true
+
+[commit_types]
+build = { changelog_title = "Build", bump_patch = true }


### PR DESCRIPTION
## Changes

Configure Cocogitto to bump the patch version when it sees a `build: ` commit.

## Context

We use the `build: ` prefix for dependabot updates. However, currently, these types of changes don't result in a version bump and a new release. The result is that downstream projects' dependabot workflows aren't picking up changes to `mobile-android-pipelines`.

For example: https://github.com/govuk-one-login/mobile-android-ui/pull/404