### PR TITLE
fix: force safe versions for vulnerable transitive dependencies in buildLogic

### DIFF
--- a/buildLogic/gradle/libs.versions.toml
+++ b/buildLogic/gradle/libs.versions.toml
@@ -15,6 +15,11 @@ ktlint-cli = "1.5.0" # https://github.com/pinterest/ktlint/releases
 kotlin-general = "2.3.20" # https://kotlinlang.org/docs/releases.html#release-details
 sonarqube-gradle = "7.2.3.7755" # https://github.com/SonarSource/sonar-scanner-gradle/releases
 
+# Minimum safe versions for vulnerable transitive dependencies
+netty = "4.1.132.Final"
+logback = "1.5.25"
+bouncycastle = "1.83"
+
 [libraries]
 
 android-build-tool = { group = "com.android.tools.build", name = "gradle", version.ref = "android-gradle" }

--- a/buildLogic/gradle/libs.versions.toml
+++ b/buildLogic/gradle/libs.versions.toml
@@ -19,6 +19,9 @@ sonarqube-gradle = "7.2.3.7755" # https://github.com/SonarSource/sonar-scanner-g
 netty = "4.1.132.Final"
 logback = "1.5.25"
 bouncycastle = "1.83"
+jdom2 = "2.0.6.1"
+jose4j = "0.9.6"
+httpclient = "4.5.13"
 
 [libraries]
 

--- a/buildLogic/plugins/build.gradle.kts
+++ b/buildLogic/plugins/build.gradle.kts
@@ -16,6 +16,11 @@ configurations.configureEach {
             "io.netty" -> useVersion(libs.versions.netty.get())
             "ch.qos.logback" -> useVersion(libs.versions.logback.get())
             "org.bouncycastle" -> useVersion(libs.versions.bouncycastle.get())
+            "org.jdom" -> useVersion(libs.versions.jdom2.get())
+            "org.bitbucket.b_c" -> useVersion(libs.versions.jose4j.get())
+            "org.apache.httpcomponents" -> if (requested.name == "httpclient") {
+                useVersion(libs.versions.httpclient.get())
+            }
         }
     }
 }

--- a/buildLogic/plugins/build.gradle.kts
+++ b/buildLogic/plugins/build.gradle.kts
@@ -9,6 +9,17 @@ plugins {
     alias(libs.plugins.buildconfig)
 }
 
+// Force safe versions for vulnerable transitive dependencies
+configurations.configureEach {
+    resolutionStrategy.eachDependency {
+        when (requested.group) {
+            "io.netty" -> useVersion(libs.versions.netty.get())
+            "ch.qos.logback" -> useVersion(libs.versions.logback.get())
+            "org.bouncycastle" -> useVersion(libs.versions.bouncycastle.get())
+        }
+    }
+}
+
 group = "uk.gov.pipelines"
 
 gradlePlugin {


### PR DESCRIPTION
Add resolution strategy to force safe versions of netty, logback, and bouncycastle in the buildLogic included build. These are transitive dependencies pulled in by AGP and Gradle plugins.