### PR TITLE
ci: Create action to download coverage report artifacts and restore them

### DIFF
--- a/actions/restore-coverage-reports/action.yml
+++ b/actions/restore-coverage-reports/action.yml
@@ -1,0 +1,23 @@
+name: 'Restore coverage reports'
+description: 'Download coverage report artifacts and restore them into the correct build directories for sonar analysis'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Download all coverage report artifacts
+      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
+      with:
+        pattern: '*-reports'
+        path: downloaded-reports
+
+    - name: Restore reports to build directories
+      shell: bash
+      run: |
+        for artifact_dir in downloaded-reports/*/; do
+          echo "Restoring from: ${artifact_dir}"
+          rsync -a "${artifact_dir}" .
+        done
+        rm -rf downloaded-reports
+
+        echo "=== Restored report files ==="
+        find . -path "*/build/reports/*" -name "*.xml" | sort | head -100


### PR DESCRIPTION
- restore them into the correct build directories for sonar analysis

Resolves: DCMAW-19621