### PR TITLE
build: roll back kotlin version due to hilt compatibility issues

### DIFF
--- a/buildLogic/gradle/libs.versions.toml
+++ b/buildLogic/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ jacoco-tool = "0.8.14" # https://github.com/jacoco/jacoco/releases
 junit = "6.1.0" # https://github.com/junit-team/junit5/releases
 ktlint-gradle = "12.2.0" # https://github.com/JLLeitschuh/ktlint-gradle/releases
 ktlint-cli = "1.5.0" # https://github.com/pinterest/ktlint/releases
-kotlin-general = "2.4.0" # https://kotlinlang.org/docs/releases.html#release-details
+kotlin-general = "2.3.20" # https://kotlinlang.org/docs/releases.html#release-details
 sonarqube-gradle = "7.3.0.8198" # https://github.com/SonarSource/sonar-scanner-gradle/releases
 
 [libraries]


### PR DESCRIPTION
build: roll back kotlin version due to hilt compatibility issues