### PR TITLE
feat: Add action for publishing GitHub releases

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -33,10 +33,18 @@ jobs:
         uses: ./actions/publish-release-tag
 
       - name: Generate Changelog
+        id: changelog
         uses: ./actions/generate-and-upload-changelog
         with:
           current-version: ${{ steps.versioning.outputs.current_version }}
           new-version: ${{ steps.versioning.outputs.new_version }}
+
+      - name: Publish GitHub Release
+        if: ${{ steps.versioning.outputs.current_version != steps.versioning.outputs.new_version }}
+        uses: ./actions/publish-github-release
+        with:
+          version: ${{ steps.versioning.outputs.new_version }}
+          changelog-path: ${{ steps.changelog.outputs.path }}
 
       - name: Clean workspace
         uses: ./actions/clean-workspace

--- a/action.yml
+++ b/action.yml
@@ -83,11 +83,21 @@ runs:
         VERSION_NAME: ${{ steps.versioning.outputs.new_version }}
 
     - name: Generate Changelog
+      id: changelog
       uses: ./mobile-android-pipelines/actions/generate-and-upload-changelog
       with:
         current-version: ${{ steps.versioning.outputs.current_version }}
         new-version: ${{ steps.versioning.outputs.new_version }}
         version-prefix: ${{ inputs.VERSION_PREFIX }}
+
+    - name: Publish GitHub Release
+      if: ${{ github.event_name != 'pull_request'
+        && steps.versioning.outputs.current_version != steps.versioning.outputs.new_version }}
+      uses: ./mobile-android-pipelines/actions/publish-github-release
+      with:
+        version: ${{ steps.versioning.outputs.new_version }}
+        version-prefix: ${{ inputs.VERSION_PREFIX }}
+        changelog-path: ${{ steps.changelog.outputs.path }}
 
     - name: Clean workspace
       uses: ./mobile-android-pipelines/actions/clean-workspace

--- a/actions/generate-and-upload-changelog/action.yml
+++ b/actions/generate-and-upload-changelog/action.yml
@@ -11,16 +11,28 @@ inputs:
     description: 'A prefix added to the Git tag before the version number'
     default: 'v'
     required: false
+outputs:
+  path:
+    description: 'Path to the generated changelog file'
+    value: ${{ steps.path.outputs.path }}
 
 runs:
   using: "composite"
   steps:
+    - name: Set Changelog path
+      id: path
+      if: ${{ inputs.current-version != inputs.new-version }}
+      run: echo "path=CHANGELOG.md" >> "$GITHUB_OUTPUT"
+      shell: bash
+
     - name: Generate Changelog
+      id: generate
       if: ${{ inputs.current-version != inputs.new-version }}
       env:
+        CHANGELOG_PATH: ${{ steps.path.outputs.path }}
         VERSION_PREFIX: ${{ inputs.version-prefix }}
       run: |
-        cog changelog --at ${VERSION_PREFIX}$(cog -v get-version) > CHANGELOG.md
+        cog changelog --at ${VERSION_PREFIX}$(cog -v get-version) > "${CHANGELOG_PATH}"
       shell: bash
 
     - name: Upload Changelog
@@ -28,5 +40,5 @@ runs:
       id: uploadBuildReports
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: CHANGELOG.md
-        path: CHANGELOG.md
+        name: ${{ steps.path.outputs.path }}
+        path: ${{ steps.path.outputs.path }}

--- a/actions/publish-github-release/action.yml
+++ b/actions/publish-github-release/action.yml
@@ -1,0 +1,28 @@
+name: 'Publish GitHub release'
+description: 'Create a GitHub release with changelog as release notes'
+inputs:
+  version:
+    description: 'The version to create a release for'
+    required: true
+  version-prefix:
+    description: 'A prefix added to the Git tag before the version number'
+    default: 'v'
+    required: false
+  changelog-path:
+    description: 'Path to the changelog file'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Publish GitHub Release
+      run: |
+        gh release create "${VERSION_PREFIX}${VERSION}" \
+          --title "${VERSION_PREFIX}${VERSION}" \
+          --notes-file "${CHANGELOG_PATH}"
+      env:
+        CHANGELOG_PATH: ${{ inputs.changelog-path }}
+        GH_TOKEN: ${{ github.token }}
+        VERSION: ${{ inputs.version }}
+        VERSION_PREFIX: ${{ inputs.version-prefix }}
+      shell: bash


### PR DESCRIPTION
## Changes

- Add a new GitHub action for publishing GitHub releases: `actions/publish-github-release`
- Add a new `path` output to the `actions/generate-and-upload-changelog` action that points to the CHANGELOG.md file
- Update the main `action.yml` to publish GitHub releases

## Context

DCMAW-17480