### PR TITLE
chore: DCMAW-20731 Remove gist reference

### DIFF
--- a/scripts/firstTimeDevSetup
+++ b/scripts/firstTimeDevSetup
@@ -53,14 +53,14 @@ function installHomebrewIfNecessary {
 # Installs all dependencies declared within the code base.
 function installProjectDependencies {
   echo "## Installing Brewfile dependencies... ##"
-  if [ ! -f brewfile ]; then
-    echo "/scripts/brewfile not found - copy from https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/6697615438/Android+Development+Setup and re-run the script"
+  if [ ! -f Brewfile ]; then
+    echo "/scripts/Brewfile not found - copy from https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/6697615438/Android+Development+Setup and re-run the script"
     exit 1
   fi
   brew bundle
 #  cd ../
-  echo "## Deleting brewfile after installations:... ##"
-  rm -rf "brewfile" 2> /dev/null
+  echo "## Deleting Brewfile after installations:... ##"
+  rm -rf "Brewfile" 2> /dev/null
 }
 
 ## SCRIPT STARTS HERE ##

--- a/scripts/firstTimeDevSetup
+++ b/scripts/firstTimeDevSetup
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 BASH_CONFIG_FILE=~/.bash_profile
-GIT_ROOT=$(git rev-parse --show-toplevel)
 ZSH_CONFIG_FILE=~/.zshrc
 
 # Checks the provided file for provided EVAL_STRING. If not, appends to the config file if it exists.

--- a/scripts/firstTimeDevSetup
+++ b/scripts/firstTimeDevSetup
@@ -3,11 +3,6 @@
 BASH_CONFIG_FILE=~/.bash_profile
 GIT_ROOT=$(git rev-parse --show-toplevel)
 ZSH_CONFIG_FILE=~/.zshrc
-# Use the address below to access the gist for the Brewfile and make any changes if required
-# shellcheck disable=SC2034
-BREW_GIST=https://gist.github.com/BiancaMihaila/6473ba331c185aa8e9551fd51e5da4a9
-# This will have to be amended to either grab the hash from the above URL or always manually updated for the hash - less likely to change
-BREW_PATH="${GIT_ROOT}/6473ba331c185aa8e9551fd51e5da4a9"
 
 # Checks the provided file for provided EVAL_STRING. If not, appends to the config file if it exists.
 # Parameters:
@@ -59,12 +54,14 @@ function installHomebrewIfNecessary {
 # Installs all dependencies declared within the code base.
 function installProjectDependencies {
   echo "## Installing Brewfile dependencies... ##"
-  git clone BREW_GIST
-  cd "${BREW_PATH}" || exit
+  if [ ! -f brewfile ]; then
+    echo "/scripts/brewfile not found - copy from https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/6697615438/Android+Development+Setup and re-run the script"
+    exit 1
+  fi
   brew bundle
-  cd ../
-  echo "## Deleting Brewfile after installations:... ##"
-  rm -rf "${BREW_PATH}" 2> /dev/null
+#  cd ../
+  echo "## Deleting brewfile after installations:... ##"
+  rm -rf "brewfile" 2> /dev/null
 }
 
 ## SCRIPT STARTS HERE ##


### PR DESCRIPTION
## What Changed

In the `firstTimeDevSetup` script, there was a reference to a brewfile hosted in a gist file outside of our control. This has been removed and has been replaced with a reference to an internal Confluence document with the necessary brewfile. This setup documentation may be improved in future, but this is a short-term fix to ensure that setup references resources in our control. 