### PR TITLE
build: Downgrade Kotlin from 2.4.0 to 2.3.21

### DIFF
--- a/buildLogic/gradle/libs.versions.toml
+++ b/buildLogic/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ jacoco-tool = "0.8.14" # https://github.com/jacoco/jacoco/releases
 junit = "6.1.0" # https://github.com/junit-team/junit5/releases
 ktlint-gradle = "12.2.0" # https://github.com/JLLeitschuh/ktlint-gradle/releases
 ktlint-cli = "1.5.0" # https://github.com/pinterest/ktlint/releases
-kotlin-general = "2.4.0" # https://kotlinlang.org/docs/releases.html#release-details
+kotlin-general = "2.3.21" # https://kotlinlang.org/docs/releases.html#release-details
 sonarqube-gradle = "7.3.1.8318" # https://github.com/SonarSource/sonar-scanner-gradle/releases
 
 [libraries]


### PR DESCRIPTION
## Context

Causes problems with the version of Hilt we're using:

https://github.com/govuk-one-login/mobile-android-one-login-app/pull/903#issuecomment-4863237370