### PR TITLE
build: Update default Java toolchain version to 21

### DIFF
--- a/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/jvm-toolchains.gradle.kts
+++ b/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/jvm-toolchains.gradle.kts
@@ -3,7 +3,7 @@ package uk.gov.pipelines
 import com.android.build.gradle.BaseExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 
-val jvmVersion by extra(17)
+val jvmVersion by extra(21)
 
 plugins {
     id("kotlin-android")


### PR DESCRIPTION
## Context

Support minimum Java version for Paparazzi 2.0.0-alpha04+
- https://github.com/cashapp/paparazzi/releases/tag/2.0.0-alpha04

DCMAW-18212