### PR TITLE
fix: update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,14 +4,6 @@
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
 updates:
-  - package-ecosystem: "gradle"
-    directories:
-      - "/buildLogic/"
-      - "/test-project/"
-    open-pull-requests-limit: 10
-    schedule:
-      interval: "weekly"
-
   - package-ecosystem: "github-actions"
     directories:
       - "/"
@@ -23,3 +15,25 @@ updates:
         applies-to: version-updates
         patterns:
           - "*"
+
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "gradle"
+    directories:
+      - "/buildLogic/"
+      - "/test-project/"
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "weekly"
+    # TODO: Remove ignore once AGP9 work is complete (DCMAW-18212)
+    ignore:
+      - dependency-name: "org.jetbrains.kotlin:*"
+      - dependency-name: "com.google.devtools.ksp:*"
+    groups:
+      kotlin:
+        patterns:
+          - "org.jetbrains.kotlin*"
+          - "com.google.devtools.ksp*"


### PR DESCRIPTION
# _update dependabot configuration_

- Re-ordered to match the other project's dependabot files, so comparison is easier
- Turn off update to gradle and kotlin as further updates are incompatible with hilt until AGP9 is complete

## JIRA ticket link:

- None

## Evidence of the change:

- The same has been done on wallet

## Checklist

### Before creating the pull request

- [x] Ran the app locally ensuring it builds.
- [x] Checks pass locally (lint, tests).
- [x] Pull request has a clear title with a short description about the feature or update.
- [x] Make sure no changes affect Release Flags, and if they do, changes are intentional.
- [x] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [ ] ~Complete all Acceptance Criteria within Jira ticket.~
- [ ] ~Complete automated testing (unit, component, snapshot, accessibility)~
- [ ] ~Successfully run changes on a testing device with the staging release app.~
- [x] Self-review code.

### Before merging the pull request

- [ ] For **Defect**, **Tech Story** and **Story** tickets: Make sure that QA has reviewed (by checking they have the correct links to the correct JIRA tickets, explain the changes in the PR description to match the JIRA ticket, screenshot/video evidence attached when necessary) and commented QA approval.
- [ ] For **Tech Debt**, **Task** and **Spike** tickets (dev-only): Make sure that developer has reviewed (by checking they have the correct links to the correct JIRA tickets, explain the changes in the PR description to match the JIRA ticket, screenshot/video evidence attached when necessary) and commented Dev QA approval.