### PR TITLE
ci: Ensure Jacoco test coverage reports are generated

### DIFF
--- a/.github/workflows/check-build-logic.yml
+++ b/.github/workflows/check-build-logic.yml
@@ -56,6 +56,7 @@ jobs:
         uses: ./actions/upload-coverage-reports
         with:
           artifact-name: build-logic-unit-test-coverage
+          if-no-files-found: error
 
   sonar-scan:
     name: Scan with Sonar

--- a/.github/workflows/check-test-project.yml
+++ b/.github/workflows/check-test-project.yml
@@ -40,6 +40,7 @@ jobs:
         uses: ./actions/upload-coverage-reports
         with:
           artifact-name: test-project-unit-test-coverage
+          if-no-files-found: error
 
   instrumentation-test:
     name: Instrumentation test
@@ -69,6 +70,7 @@ jobs:
         uses: ./actions/upload-coverage-reports
         with:
           artifact-name: test-project-instrumentation-test-coverage
+          if-no-files-found: error
 
   dependency-submission:
     name: Dependency submission

--- a/actions/upload-coverage-reports/action.yml
+++ b/actions/upload-coverage-reports/action.yml
@@ -8,6 +8,10 @@ inputs:
     description: "Path for the reports"
     required: false
     default: "**/reports/jacoco/**/*.xml"
+  if-no-files-found:
+    description: "Behaviour if no coverage reports are found. Options: warn, error, ignore."
+    required: false
+    default: "warn"
 
 runs:
   using: "composite"
@@ -17,3 +21,4 @@ runs:
       with:
         name: ${{ inputs.artifact-name }}
         path: ${{ inputs.path }}
+        if-no-files-found: ${{ inputs.if-no-files-found }}


### PR DESCRIPTION
## Context

Currently, if Jacoco report generation breaks, it's not immediately obvious.

Sonar only reports changes to coverage on new code.

This change validates that at least some Jacoco reports were generated by the plugins.

DCMAW-18212