### PR TITLE
ci: Re-enable Dependabot Kotlin updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,10 +28,6 @@ updates:
     open-pull-requests-limit: 10
     schedule:
       interval: "weekly"
-    # TODO: Remove ignore once AGP9 work is complete (DCMAW-18212)
-    ignore:
-      - dependency-name: "org.jetbrains.kotlin:*"
-      - dependency-name: "com.google.devtools.ksp:*"
     groups:
       kotlin:
         patterns:


### PR DESCRIPTION
DCMAW-18212

- https://github.com/govuk-one-login/mobile-android-pipelines/pull/358