### PR TITLE
refactor: Remove deprecated AGP lint config

### DIFF
--- a/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/extensions/LintExtensions.kt
+++ b/buildLogic/plugins/src/main/kotlin/uk/gov/pipelines/extensions/LintExtensions.kt
@@ -30,15 +30,12 @@ object LintExtensions {
                 ),
             )
             explainIssues = true
-            htmlReport = true
             ignoreTestSources = true
             ignoreWarnings = false
             lintConfig = File("$configDir/android/lint.xml")
             noLines = false
             quiet = false
             showAll = true
-            textReport = true
             warningsAsErrors = true
-            xmlReport = true
         }
 }


### PR DESCRIPTION
## Context

Addresses warning:

```
w: 'var htmlReport: Boolean' is deprecated. Lint reports are now always generated. Use SingleArtifact.LINT_HTML_REPORT or SingleArtifact.AGGREGATED_LINT_HTML_REPORT to consume lint report artifacts.
w: 'var textReport: Boolean' is deprecated. Lint reports are now always generated. Use SingleArtifact.LINT_TEXT_REPORT or SingleArtifact.AGGREGATED_LINT_TEXT_REPORT to consume lint report artifacts.
w: 'var xmlReport: Boolean' is deprecated. Lint reports are now always generated. Use SingleArtifact.LINT_XML_REPORT or SingleArtifact.AGGREGATED_LINT_XML_REPORT to consume lint report artifacts.
```